### PR TITLE
Add pytest tests and GitHub workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,26 @@
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pytest
+    - name: Run tests
+      run: |
+        pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,40 @@
+import io
+import os
+import sys
+
+import pytest
+from werkzeug.datastructures import FileStorage
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import main
+
+
+# Tests for normalize_personnummer
+
+def test_normalize_personnummer_valid():
+    assert main.normalize_personnummer(" 19900101-1234 ") == "19900101-1234"
+
+
+def test_normalize_personnummer_invalid():
+    with pytest.raises(ValueError):
+        main.normalize_personnummer("abc")
+
+
+# Tests for save_pdf_for_user
+
+def test_save_pdf_for_user(tmp_path, monkeypatch):
+    monkeypatch.setitem(main.app.config, "UPLOAD_ROOT", tmp_path)
+
+    pdf_bytes = b"%PDF-1.4 test"
+    file_storage = FileStorage(
+        stream=io.BytesIO(pdf_bytes),
+        filename="test.pdf",
+        content_type="application/pdf",
+    )
+
+    rel_path = main.save_pdf_for_user("19900101-1234", file_storage)
+
+    abs_path = os.path.abspath(os.path.join(main.APP_ROOT, rel_path))
+    assert os.path.exists(abs_path)
+    with open(abs_path, "rb") as f:
+        assert f.read() == pdf_bytes


### PR DESCRIPTION
## Summary
- add unit tests for personal number normalization and PDF uploads
- add GitHub Actions workflow running pytest

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4a5555fdc832d80481b82a1b22d12