### PR TITLE
Avoid storing PDF paths in DB and derive from uploads

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -15,8 +15,7 @@ def create_database():
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             username TEXT NOT NULL,
             email TEXT NOT NULL,
-            personnummer TEXT NOT NULL,
-            pdf_path TEXT NOT NULL
+            personnummer TEXT NOT NULL
         )
     ''')
     cursor.execute('''
@@ -25,8 +24,7 @@ def create_database():
             username TEXT NOT NULL,
             email TEXT NOT NULL,
             password TEXT NOT NULL,
-            personnummer TEXT NOT NULL,
-            pdf_path TEXT NOT NULL
+            personnummer TEXT NOT NULL
         )
     ''')
     conn.commit()
@@ -85,16 +83,16 @@ def check_pending_user(personnummer):
     conn.close()
     return user is not None
 
-def admin_create_user(email, username, personnummer, pdf_path):
+def admin_create_user(email, username, personnummer):
     if check_user_exists(email):
         return False
 
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
     cursor.execute('''
-        INSERT INTO pending_users (email, username, personnummer, pdf_path)
-        VALUES (?, ?, ?, ?)
-    ''', (email, username, personnummer, pdf_path))
+        INSERT INTO pending_users (email, username, personnummer)
+        VALUES (?, ?, ?)
+    ''', (email, username, personnummer))
     conn.commit()
     conn.close()
     return True
@@ -108,29 +106,29 @@ def user_create_user(password, personnummer):
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
     try:
-        
+
         # Hämta användaren från pending_users
         cursor.execute('''
-            SELECT email, username, personnummer, pdf_path 
-            FROM pending_users 
+            SELECT email, username, personnummer
+            FROM pending_users
             WHERE personnummer = ?
         ''', (personnummer,))
         row = cursor.fetchone()
         if not row:
             return False
-        
 
-        email, username, personnummer, pdf_path = row
-        print(f"Skapar användare: {email}, {username}, {personnummer}, {pdf_path}")
+
+        email, username, personnummer = row
+        print(f"Skapar användare: {email}, {username}, {personnummer}")
 
         # Ta bort från pending_users
         cursor.execute('DELETE FROM pending_users WHERE personnummer = ?', (personnummer,))
         print("Användare borttagen från pending_users")
         # Lägg in i users
         cursor.execute('''
-            INSERT INTO users (email, password, username, personnummer, pdf_path)
-            VALUES (?, ?, ?, ?, ?)
-        ''', (email, password, username, personnummer, pdf_path))
+            INSERT INTO users (email, password, username, personnummer)
+            VALUES (?, ?, ?, ?)
+        ''', (email, password, username, personnummer))
         print("Användare skapad i users")
 
         conn.commit()
@@ -157,5 +155,4 @@ def create_test_user():
     email = "test@example.com"
     username = "Test User"
     personnummer = "199001011234"
-    pdf_path = "static/uploads/test.pdf"
-    admin_create_user(email, username, personnummer, pdf_path)
+    admin_create_user(email, username, personnummer)

--- a/main.py
+++ b/main.py
@@ -114,11 +114,10 @@ def admin():
                     return jsonify({'status': 'error', 'message': 'PDF-fil saknas'}), 400
 
                 # spara filen i mapp per personnummer
-                pdf_path = save_pdf_for_user(personnummer, pdf_file)
+                save_pdf_for_user(personnummer, pdf_file)
 
-                # lagra den relativa sökvägen i DB
-                if functions.admin_create_user(email, username, personnummer, pdf_path):
-                    return jsonify({'status': 'success', 'message': 'User created successfully', 'pdf_path': pdf_path})
+                if functions.admin_create_user(email, username, personnummer):
+                    return jsonify({'status': 'success', 'message': 'User created successfully'})
                 else:
                     return jsonify({'status': 'error', 'message': 'User already exists'}), 409
             except ValueError as ve:

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -110,7 +110,7 @@
       }
 
       if (res.ok && data && data.status === 'success') {
-        showMessage('success', `Användare skapad. PDF-sökväg: ${data.pdf_path}`);
+        showMessage('success', 'Användare skapad.');
         form.reset();
       } else {
         const msg =

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -58,8 +58,8 @@ def setup_user(tmp_path, monkeypatch):
     conn = real_connect(db_path)
     cursor = conn.cursor()
     cursor.execute(
-        "INSERT INTO users (username, email, password, personnummer, pdf_path) VALUES (?, ?, ?, ?, ?)",
-        ("Test", "test@example.com", "secret", "199001011234", "path.pdf"),
+        "INSERT INTO users (username, email, password, personnummer) VALUES (?, ?, ?, ?)",
+        ("Test", "test@example.com", "secret", "199001011234"),
     )
     conn.commit()
     conn.close()


### PR DESCRIPTION
## Summary
- Drop `pdf_path` columns from user tables and related functions
- Save PDFs under `uploads/<personnummer>` and stop returning stored paths
- Update admin client and tests to match new PDF handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4ae7e31d4832d93838c75a1208224