### PR TITLE
Add user dashboard to view uploaded PDFs

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -1,6 +1,24 @@
 import sqlite3
 import hashlib
+import re
+from datetime import datetime
 
+
+def normalize_personnummer(pnr: str) -> str:
+    """Normalize Swedish personal numbers to 12 digits.
+
+    Accepts inputs with or without separators (e.g., YYMMDD-XXXX, YYYYMMDDXXXX).
+    Returns a string with only digits (YYYYMMDDXXXX).
+    """
+    digits = re.sub(r"\D", "", pnr)
+    if len(digits) == 10:  # YYMMDDXXXX
+        year = int(digits[:2])
+        current_year = datetime.now().year % 100
+        century = datetime.now().year // 100 - (1 if year > current_year else 0)
+        digits = f"{century:02d}{digits}"
+    if len(digits) != 12:
+        raise ValueError("Ogiltigt personnummerformat.")
+    return digits
 
 
 
@@ -44,6 +62,7 @@ def check_password_user(email, password):
 
 def check_personnummer_password(personnummer: str, password: str) -> bool:
     """Returnera True om personnummer och lösenord matchar en användare."""
+    personnummer = normalize_personnummer(personnummer)
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
     cursor.execute(
@@ -75,6 +94,7 @@ def get_username(email):
     return user[0] if user else None
 
 def check_pending_user(personnummer):
+    personnummer = normalize_personnummer(personnummer)
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
     cursor.execute('''
@@ -88,6 +108,7 @@ def admin_create_user(email, username, personnummer, pdf_path):
     if check_user_exists(email):
         return False
 
+    personnummer = normalize_personnummer(personnummer)
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
     cursor.execute(
@@ -103,6 +124,7 @@ def admin_create_user(email, username, personnummer, pdf_path):
 
 
 def user_create_user(password, personnummer):
+    personnummer = normalize_personnummer(personnummer)
     if check_user_exists(personnummer):
         print("Användare finns redan")
         return False
@@ -146,6 +168,7 @@ def user_create_user(password, personnummer):
 
 
 def get_user_info(personnummer):
+    personnummer = normalize_personnummer(personnummer)
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
     cursor.execute('''

--- a/functions.py
+++ b/functions.py
@@ -15,7 +15,8 @@ def create_database():
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             username TEXT NOT NULL,
             email TEXT NOT NULL,
-            personnummer TEXT NOT NULL
+            personnummer TEXT NOT NULL,
+            pdf_path TEXT NOT NULL
         )
     ''')
     cursor.execute('''
@@ -83,16 +84,19 @@ def check_pending_user(personnummer):
     conn.close()
     return user is not None
 
-def admin_create_user(email, username, personnummer):
+def admin_create_user(email, username, personnummer, pdf_path):
     if check_user_exists(email):
         return False
 
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
-    cursor.execute('''
-        INSERT INTO pending_users (email, username, personnummer)
-        VALUES (?, ?, ?)
-    ''', (email, username, personnummer))
+    cursor.execute(
+        '''
+        INSERT INTO pending_users (email, username, personnummer, pdf_path)
+        VALUES (?, ?, ?, ?)
+        ''',
+        (email, username, personnummer, pdf_path),
+    )
     conn.commit()
     conn.close()
     return True
@@ -155,4 +159,4 @@ def create_test_user():
     email = "test@example.com"
     username = "Test User"
     personnummer = "199001011234"
-    admin_create_user(email, username, personnummer)
+    admin_create_user(email, username, personnummer, "dummy.pdf")

--- a/main.py
+++ b/main.py
@@ -140,6 +140,15 @@ def admin():
                 # spara filen i mapp per personnummer
                 pdf_path = save_pdf_for_user(personnummer, pdf_file)
 
+                # Om användaren redan finns ska endast PDF:en sparas
+                if functions.get_user_info(personnummer):
+                    return jsonify(
+                        {
+                            'status': 'success',
+                            'message': 'PDF uploaded for existing user',
+                        }
+                    )
+
                 if functions.admin_create_user(email, username, personnummer, pdf_path):
                     return jsonify({'status': 'success', 'message': 'User created successfully'})
                 else:

--- a/main.py
+++ b/main.py
@@ -153,9 +153,9 @@ def admin():
                     return jsonify({'status': 'error', 'message': 'PDF-fil saknas'}), 400
 
                 # spara filen i mapp per personnummer
-                save_pdf_for_user(personnummer, pdf_file)
+                pdf_path = save_pdf_for_user(personnummer, pdf_file)
 
-                if functions.admin_create_user(email, username, personnummer):
+                if functions.admin_create_user(email, username, personnummer, pdf_path):
                     return jsonify({'status': 'success', 'message': 'User created successfully'})
                 else:
                     return jsonify({'status': 'error', 'message': 'User already exists'}), 409

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<h1>Your PDFs</h1>
+{% if pdfs %}
+<ul>
+    {% for pdf in pdfs %}
+    <li><a href="{{ url_for('download_pdf', filename=pdf) }}">{{ pdf }}</a></li>
+    {% endfor %}
+</ul>
+{% else %}
+<p>No PDFs uploaded.</p>
+{% endif %}
+{% endblock %}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -81,3 +81,24 @@ def test_login_failure(tmp_path, monkeypatch):
             "/login", data={"personnummer": "199001011234", "password": "wrong"}
         )
         assert response.status_code == 401
+
+
+def test_dashboard_shows_only_user_pdfs(tmp_path, monkeypatch):
+    setup_user(tmp_path, monkeypatch)
+    monkeypatch.setitem(main.app.config, "UPLOAD_ROOT", tmp_path)
+
+    user_dir = tmp_path / "199001011234"
+    user_dir.mkdir()
+    (user_dir / "own.pdf").write_text("test")
+
+    other_dir = tmp_path / "200001011234"
+    other_dir.mkdir()
+    (other_dir / "other.pdf").write_text("test")
+
+    with main.app.test_client() as client:
+        client.post(
+            "/login", data={"personnummer": "199001011234", "password": "secret"}
+        )
+        response = client.get("/dashboard")
+        assert b"own.pdf" in response.data
+        assert b"other.pdf" not in response.data


### PR DESCRIPTION
## Summary
- Add dashboard and download routes to list a user's PDF files only for their session
- Create dashboard template showing links to each uploaded PDF
- Test dashboard to ensure users only see their own PDFs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4b1aaae98832d95642f8755f111f8