### PR TITLE
Hash sensitive fields

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -1,7 +1,17 @@
 import sqlite3
 import hashlib
+import os
 import re
 from datetime import datetime
+
+# Simple helper for hashing with a global salt. In a real application this
+# should be replaced with a per-user salt and a stronger hashing algorithm.
+SALT = os.getenv("HASH_SALT", "static_salt")
+
+
+def hash_value(value: str) -> str:
+    """Return a SHA-256 hash of ``value`` combined with a salt."""
+    return hashlib.sha256((value + SALT).encode()).hexdigest()
 
 
 def normalize_personnummer(pnr: str) -> str:
@@ -52,22 +62,23 @@ def create_database():
 def check_password_user(email, password):
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
-    cursor.execute('''
-        SELECT * FROM users WHERE email = ? AND password = ?
-    ''', (email, hashlib.sha256(password.encode()).hexdigest()))
+    cursor.execute(
+        '''SELECT * FROM users WHERE email = ? AND password = ?''',
+        (hash_value(email), hash_value(password)),
+    )
     user = cursor.fetchone()
     conn.close()
     return user is not None
 
 
 def check_personnummer_password(personnummer: str, password: str) -> bool:
-    """Returnera True om personnummer och lösenord matchar en användare."""
+    """Return True if the hashed personnummer and password match a user."""
     personnummer = normalize_personnummer(personnummer)
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
     cursor.execute(
         '''SELECT * FROM users WHERE personnummer = ? AND password = ?''',
-        (personnummer, password),
+        (hash_value(personnummer), hash_value(password)),
     )
     user = cursor.fetchone()
     conn.close()
@@ -76,9 +87,10 @@ def check_personnummer_password(personnummer: str, password: str) -> bool:
 def check_user_exists(email):
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
-    cursor.execute('''
-        SELECT * FROM users WHERE email = ?
-    ''', (email,))
+    cursor.execute(
+        '''SELECT * FROM users WHERE email = ?''',
+        (hash_value(email),),
+    )
     user = cursor.fetchone()
     conn.close()
     return user is not None
@@ -86,9 +98,10 @@ def check_user_exists(email):
 def get_username(email):
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
-    cursor.execute('''
-        SELECT username FROM users WHERE email = ?
-    ''', (email,))
+    cursor.execute(
+        '''SELECT username FROM users WHERE email = ?''',
+        (hash_value(email),),
+    )
     user = cursor.fetchone()
     conn.close()
     return user[0] if user else None
@@ -97,9 +110,10 @@ def check_pending_user(personnummer):
     personnummer = normalize_personnummer(personnummer)
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
-    cursor.execute('''
-        SELECT * FROM pending_users WHERE personnummer = ?
-    ''', (personnummer,))
+    cursor.execute(
+        '''SELECT * FROM pending_users WHERE personnummer = ?''',
+        (hash_value(personnummer),),
+    )
     user = cursor.fetchone()
     conn.close()
     return user is not None
@@ -116,7 +130,7 @@ def admin_create_user(email, username, personnummer, pdf_path):
         INSERT INTO pending_users (email, username, personnummer, pdf_path)
         VALUES (?, ?, ?, ?)
         ''',
-        (email, username, personnummer, pdf_path),
+        (hash_value(email), username, hash_value(personnummer), pdf_path),
     )
     conn.commit()
     conn.close()
@@ -125,7 +139,7 @@ def admin_create_user(email, username, personnummer, pdf_path):
 
 def user_create_user(password, personnummer):
     personnummer = normalize_personnummer(personnummer)
-    if check_user_exists(personnummer):
+    if get_user_info(personnummer):
         print("Användare finns redan")
         return False
 
@@ -134,27 +148,35 @@ def user_create_user(password, personnummer):
     try:
 
         # Hämta användaren från pending_users
-        cursor.execute('''
+        cursor.execute(
+            '''
             SELECT email, username, personnummer
             FROM pending_users
             WHERE personnummer = ?
-        ''', (personnummer,))
+            ''',
+            (hash_value(personnummer),),
+        )
         row = cursor.fetchone()
         if not row:
             return False
 
-
-        email, username, personnummer = row
-        print(f"Skapar användare: {email}, {username}, {personnummer}")
+        email_hashed, username, pnr_hash = row
+        print(f"Skapar användare: {email_hashed}, {username}, {pnr_hash}")
 
         # Ta bort från pending_users
-        cursor.execute('DELETE FROM pending_users WHERE personnummer = ?', (personnummer,))
+        cursor.execute(
+            'DELETE FROM pending_users WHERE personnummer = ?',
+            (hash_value(personnummer),),
+        )
         print("Användare borttagen från pending_users")
         # Lägg in i users
-        cursor.execute('''
+        cursor.execute(
+            '''
             INSERT INTO users (email, password, username, personnummer)
             VALUES (?, ?, ?, ?)
-        ''', (email, password, username, personnummer))
+            ''',
+            (email_hashed, hash_value(password), username, pnr_hash),
+        )
         print("Användare skapad i users")
 
         conn.commit()
@@ -171,9 +193,10 @@ def get_user_info(personnummer):
     personnummer = normalize_personnummer(personnummer)
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
-    cursor.execute('''
-        SELECT * FROM users WHERE personnummer = ?
-    ''', (personnummer,))
+    cursor.execute(
+        '''SELECT * FROM users WHERE personnummer = ?''',
+        (hash_value(personnummer),),
+    )
     user = cursor.fetchone()
     conn.close()
     return user

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -61,7 +61,12 @@ def setup_user(tmp_path, monkeypatch):
     cursor = conn.cursor()
     cursor.execute(
         "INSERT INTO users (username, email, password, personnummer) VALUES (?, ?, ?, ?)",
-        ("Test", "test@example.com", "secret", "199001011234"),
+        (
+            "Test",
+            functions.hash_value("test@example.com"),
+            functions.hash_value("secret"),
+            functions.hash_value("199001011234"),
+        ),
     )
     conn.commit()
     conn.close()
@@ -91,11 +96,11 @@ def test_dashboard_shows_only_user_pdfs(tmp_path, monkeypatch):
     setup_user(tmp_path, monkeypatch)
     monkeypatch.setitem(main.app.config, "UPLOAD_ROOT", tmp_path)
 
-    user_dir = tmp_path / "199001011234"
+    user_dir = tmp_path / functions.hash_value("199001011234")
     user_dir.mkdir()
     (user_dir / "own.pdf").write_text("test")
 
-    other_dir = tmp_path / "200001011234"
+    other_dir = tmp_path / functions.hash_value("200001011234")
     other_dir.mkdir()
     (other_dir / "other.pdf").write_text("test")
 
@@ -125,14 +130,10 @@ def setup_db(tmp_path, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "pnr_input, expected_dir",
-    [
-        ("199001011234", "199001011234"),
-        ("19900101-1234", "199001011234"),
-        ("900101-1234", "199001011234"),
-    ],
+    "pnr_input",
+    ["199001011234", "19900101-1234", "900101-1234"],
 )
-def test_admin_upload_creates_pending_user(tmp_path, monkeypatch, pnr_input, expected_dir):
+def test_admin_upload_creates_pending_user(tmp_path, monkeypatch, pnr_input):
     db_path = setup_db(tmp_path, monkeypatch)
     monkeypatch.setitem(main.app.config, "UPLOAD_ROOT", tmp_path)
 
@@ -151,17 +152,20 @@ def test_admin_upload_creates_pending_user(tmp_path, monkeypatch, pnr_input, exp
         assert response.status_code == 200
         assert response.get_json()["status"] == "success"
 
+    pnr_norm = functions.normalize_personnummer(pnr_input)
+    expected_dir = functions.hash_value(pnr_norm)
+
     # Verify file saved
     user_dir = tmp_path / expected_dir
     files = list(user_dir.glob("*.pdf"))
     assert len(files) == 1
 
-    # Verify database entry contains normalized personnummer and pdf_path
+    # Verify database entry contains hashed personnummer and pdf_path
     conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
     cursor.execute(
         "SELECT personnummer, pdf_path FROM pending_users WHERE email=?",
-        ("new@example.com",),
+        (functions.hash_value("new@example.com"),),
     )
     row = cursor.fetchone()
     conn.close()
@@ -179,7 +183,12 @@ def test_admin_upload_existing_user_only_saves_pdf(tmp_path, monkeypatch):
     cursor = conn.cursor()
     cursor.execute(
         "INSERT INTO users (username, email, password, personnummer) VALUES (?, ?, ?, ?)",
-        ("Existing", "exist@example.com", "secret", "199001011234"),
+        (
+            "Existing",
+            functions.hash_value("exist@example.com"),
+            functions.hash_value("secret"),
+            functions.hash_value("199001011234"),
+        ),
     )
     conn.commit()
     conn.close()


### PR DESCRIPTION
## Summary
- hash personal number, email, and password with a salted SHA-256 helper
- store hashed personal numbers in upload paths and session data
- adjust tests for hashing changes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a89ae98188832da649640c29645728