### PR TITLE
Hash sensitive fields

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -1,7 +1,17 @@
 import sqlite3
 import hashlib
+import os
 import re
 from datetime import datetime
+
+# Simple helper for hashing with a global salt. In a real application this
+# should be replaced with a per-user salt and a stronger hashing algorithm.
+SALT = os.getenv("HASH_SALT", "static_salt")
+
+
+def hash_value(value: str) -> str:
+    """Return a SHA-256 hash of ``value`` combined with a salt."""
+    return hashlib.sha256((value + SALT).encode()).hexdigest()
 
 
 def normalize_personnummer(pnr: str) -> str:
@@ -52,22 +62,23 @@ def create_database():
 def check_password_user(email, password):
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
-    cursor.execute('''
-        SELECT * FROM users WHERE email = ? AND password = ?
-    ''', (email, hashlib.sha256(password.encode()).hexdigest()))
+    cursor.execute(
+        '''SELECT * FROM users WHERE email = ? AND password = ?''',
+        (hash_value(email), hash_value(password)),
+    )
     user = cursor.fetchone()
     conn.close()
     return user is not None
 
 
 def check_personnummer_password(personnummer: str, password: str) -> bool:
-    """Returnera True om personnummer och lösenord matchar en användare."""
+    """Return True if the hashed personnummer and password match a user."""
     personnummer = normalize_personnummer(personnummer)
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
     cursor.execute(
         '''SELECT * FROM users WHERE personnummer = ? AND password = ?''',
-        (personnummer, password),
+        (hash_value(personnummer), hash_value(password)),
     )
     user = cursor.fetchone()
     conn.close()
@@ -76,9 +87,10 @@ def check_personnummer_password(personnummer: str, password: str) -> bool:
 def check_user_exists(email):
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
-    cursor.execute('''
-        SELECT * FROM users WHERE email = ?
-    ''', (email,))
+    cursor.execute(
+        '''SELECT * FROM users WHERE email = ?''',
+        (hash_value(email),),
+    )
     user = cursor.fetchone()
     conn.close()
     return user is not None
@@ -86,9 +98,10 @@ def check_user_exists(email):
 def get_username(email):
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
-    cursor.execute('''
-        SELECT username FROM users WHERE email = ?
-    ''', (email,))
+    cursor.execute(
+        '''SELECT username FROM users WHERE email = ?''',
+        (hash_value(email),),
+    )
     user = cursor.fetchone()
     conn.close()
     return user[0] if user else None
@@ -97,9 +110,10 @@ def check_pending_user(personnummer):
     personnummer = normalize_personnummer(personnummer)
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
-    cursor.execute('''
-        SELECT * FROM pending_users WHERE personnummer = ?
-    ''', (personnummer,))
+    cursor.execute(
+        '''SELECT * FROM pending_users WHERE personnummer = ?''',
+        (hash_value(personnummer),),
+    )
     user = cursor.fetchone()
     conn.close()
     return user is not None
@@ -116,7 +130,7 @@ def admin_create_user(email, username, personnummer, pdf_path):
         INSERT INTO pending_users (email, username, personnummer, pdf_path)
         VALUES (?, ?, ?, ?)
         ''',
-        (email, username, personnummer, pdf_path),
+        (hash_value(email), username, hash_value(personnummer), pdf_path),
     )
     conn.commit()
     conn.close()
@@ -125,7 +139,7 @@ def admin_create_user(email, username, personnummer, pdf_path):
 
 def user_create_user(password, personnummer):
     personnummer = normalize_personnummer(personnummer)
-    if check_user_exists(personnummer):
+    if get_user_info(personnummer):
         print("Användare finns redan")
         return False
 
@@ -134,27 +148,35 @@ def user_create_user(password, personnummer):
     try:
 
         # Hämta användaren från pending_users
-        cursor.execute('''
+        cursor.execute(
+            '''
             SELECT email, username, personnummer
             FROM pending_users
             WHERE personnummer = ?
-        ''', (personnummer,))
+            ''',
+            (hash_value(personnummer),),
+        )
         row = cursor.fetchone()
         if not row:
             return False
 
-
-        email, username, personnummer = row
-        print(f"Skapar användare: {email}, {username}, {personnummer}")
+        email_hashed, username, pnr_hash = row
+        print(f"Skapar användare: {email_hashed}, {username}, {pnr_hash}")
 
         # Ta bort från pending_users
-        cursor.execute('DELETE FROM pending_users WHERE personnummer = ?', (personnummer,))
+        cursor.execute(
+            'DELETE FROM pending_users WHERE personnummer = ?',
+            (hash_value(personnummer),),
+        )
         print("Användare borttagen från pending_users")
         # Lägg in i users
-        cursor.execute('''
+        cursor.execute(
+            '''
             INSERT INTO users (email, password, username, personnummer)
             VALUES (?, ?, ?, ?)
-        ''', (email, password, username, personnummer))
+            ''',
+            (email_hashed, hash_value(password), username, pnr_hash),
+        )
         print("Användare skapad i users")
 
         conn.commit()
@@ -171,9 +193,10 @@ def get_user_info(personnummer):
     personnummer = normalize_personnummer(personnummer)
     conn = sqlite3.connect('database.db')
     cursor = conn.cursor()
-    cursor.execute('''
-        SELECT * FROM users WHERE personnummer = ?
-    ''', (personnummer,))
+    cursor.execute(
+        '''SELECT * FROM users WHERE personnummer = ?''',
+        (hash_value(personnummer),),
+    )
     user = cursor.fetchone()
     conn.close()
     return user

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from flask import (
 )
 from smtplib import SMTP
 import functions
-from functions import normalize_personnummer
+from functions import normalize_personnummer, hash_value
 import os
 import time
 from werkzeug.utils import secure_filename
@@ -29,7 +29,7 @@ ALLOWED_MIMES = {'application/pdf'}
 
 
 def save_pdf_for_user(pnr: str, file_storage) -> str:
-    """Spara PDF i uploads/<pnr>/ och returnera relativ sökväg (t.ex. 'uploads/199001011234/12345_cv.pdf')."""
+    """Spara PDF i uploads/<hash(pnr)>/ och returnera relativ sökväg."""
     if file_storage.filename == '':
         raise ValueError("Ingen fil vald.")
 
@@ -43,7 +43,8 @@ def save_pdf_for_user(pnr: str, file_storage) -> str:
         raise ValueError("Filen verkar inte vara en giltig PDF.")
 
     pnr_norm = normalize_personnummer(pnr)
-    user_dir = os.path.join(app.config['UPLOAD_ROOT'], pnr_norm)
+    pnr_hash = hash_value(pnr_norm)
+    user_dir = os.path.join(app.config['UPLOAD_ROOT'], pnr_hash)
     os.makedirs(user_dir, exist_ok=True)
 
     base = secure_filename(file_storage.filename)
@@ -85,7 +86,7 @@ def login():
         password = request.form['password']
         if functions.check_personnummer_password(personnummer, password):
             session['user_logged_in'] = True
-            session['personnummer'] = personnummer
+            session['personnummer'] = hash_value(personnummer)
             return redirect('/dashboard')
         else:
             return (
@@ -100,12 +101,8 @@ def dashboard():
     """Visa alla PDF:er för den inloggade användaren."""
     if not session.get('user_logged_in'):
         return redirect('/login')
-    pnr = session.get('personnummer')
-    try:
-        pnr_norm = normalize_personnummer(pnr)
-    except Exception:
-        return redirect('/login')
-    user_dir = os.path.join(app.config['UPLOAD_ROOT'], pnr_norm)
+    pnr_hash = session.get('personnummer')
+    user_dir = os.path.join(app.config['UPLOAD_ROOT'], pnr_hash)
     pdfs = []
     if os.path.isdir(user_dir):
         pdfs = [f for f in os.listdir(user_dir) if f.lower().endswith('.pdf')]
@@ -116,12 +113,8 @@ def dashboard():
 def download_pdf(filename):
     if not session.get('user_logged_in'):
         return redirect('/login')
-    pnr = session.get('personnummer')
-    try:
-        pnr_norm = normalize_personnummer(pnr)
-    except Exception:
-        return redirect('/login')
-    user_dir = os.path.join(app.config['UPLOAD_ROOT'], pnr_norm)
+    pnr_hash = session.get('personnummer')
+    user_dir = os.path.join(app.config['UPLOAD_ROOT'], pnr_hash)
     return send_from_directory(user_dir, filename, as_attachment=True)
 
 @app.route('/admin', methods=['POST', 'GET'])
@@ -150,7 +143,14 @@ def admin():
                     )
 
                 if functions.admin_create_user(email, username, personnummer, pdf_path):
-                    return jsonify({'status': 'success', 'message': 'User created successfully'})
+                    link = f"/create_user/{personnummer}"
+                    return jsonify(
+                        {
+                            'status': 'success',
+                            'message': 'User created successfully',
+                            'link': link,
+                        }
+                    )
                 else:
                     return jsonify({'status': 'error', 'message': 'User already exists'}), 409
             except ValueError as ve:

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -18,10 +18,14 @@
   const ALLOWED_MIME = 'application/pdf';
 
   // --- Hjälpmeddelanden ---
-  function showMessage(type, text) {
+  function showMessage(type, text, isHtml = false) {
     result.style.display = 'block';
     result.className = `message ${type}`;
-    result.textContent = text;
+    if (isHtml) {
+      result.innerHTML = text;
+    } else {
+      result.textContent = text;
+    }
   }
   function hideMessage() {
     result.style.display = 'none';
@@ -110,7 +114,10 @@
       }
 
       if (res.ok && data && data.status === 'success') {
-        showMessage('success', 'Användare skapad.');
+        const msg = data.link
+          ? `Användare skapad. Länk: <a href="${data.link}">${data.link}</a>`
+          : 'Användare skapad.';
+        showMessage('success', msg, !!data.link);
         form.reset();
       } else {
         const msg =

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -61,7 +61,12 @@ def setup_user(tmp_path, monkeypatch):
     cursor = conn.cursor()
     cursor.execute(
         "INSERT INTO users (username, email, password, personnummer) VALUES (?, ?, ?, ?)",
-        ("Test", "test@example.com", "secret", "199001011234"),
+        (
+            "Test",
+            functions.hash_value("test@example.com"),
+            functions.hash_value("secret"),
+            functions.hash_value("199001011234"),
+        ),
     )
     conn.commit()
     conn.close()
@@ -91,11 +96,11 @@ def test_dashboard_shows_only_user_pdfs(tmp_path, monkeypatch):
     setup_user(tmp_path, monkeypatch)
     monkeypatch.setitem(main.app.config, "UPLOAD_ROOT", tmp_path)
 
-    user_dir = tmp_path / "199001011234"
+    user_dir = tmp_path / functions.hash_value("199001011234")
     user_dir.mkdir()
     (user_dir / "own.pdf").write_text("test")
 
-    other_dir = tmp_path / "200001011234"
+    other_dir = tmp_path / functions.hash_value("200001011234")
     other_dir.mkdir()
     (other_dir / "other.pdf").write_text("test")
 
@@ -125,14 +130,10 @@ def setup_db(tmp_path, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "pnr_input, expected_dir",
-    [
-        ("199001011234", "199001011234"),
-        ("19900101-1234", "199001011234"),
-        ("900101-1234", "199001011234"),
-    ],
+    "pnr_input",
+    ["199001011234", "19900101-1234", "900101-1234"],
 )
-def test_admin_upload_creates_pending_user(tmp_path, monkeypatch, pnr_input, expected_dir):
+def test_admin_upload_creates_pending_user(tmp_path, monkeypatch, pnr_input):
     db_path = setup_db(tmp_path, monkeypatch)
     monkeypatch.setitem(main.app.config, "UPLOAD_ROOT", tmp_path)
 
@@ -149,19 +150,27 @@ def test_admin_upload_creates_pending_user(tmp_path, monkeypatch, pnr_input, exp
             sess["admin_logged_in"] = True
         response = client.post("/admin", data=data, content_type="multipart/form-data")
         assert response.status_code == 200
-        assert response.get_json()["status"] == "success"
+        resp_json = response.get_json()
+        assert resp_json["status"] == "success"
+        assert (
+            resp_json["link"]
+            == f"/create_user/{functions.normalize_personnummer(pnr_input)}"
+        )
+
+    pnr_norm = functions.normalize_personnummer(pnr_input)
+    expected_dir = functions.hash_value(pnr_norm)
 
     # Verify file saved
     user_dir = tmp_path / expected_dir
     files = list(user_dir.glob("*.pdf"))
     assert len(files) == 1
 
-    # Verify database entry contains normalized personnummer and pdf_path
+    # Verify database entry contains hashed personnummer and pdf_path
     conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
     cursor.execute(
         "SELECT personnummer, pdf_path FROM pending_users WHERE email=?",
-        ("new@example.com",),
+        (functions.hash_value("new@example.com"),),
     )
     row = cursor.fetchone()
     conn.close()
@@ -179,7 +188,12 @@ def test_admin_upload_existing_user_only_saves_pdf(tmp_path, monkeypatch):
     cursor = conn.cursor()
     cursor.execute(
         "INSERT INTO users (username, email, password, personnummer) VALUES (?, ?, ?, ?)",
-        ("Existing", "exist@example.com", "secret", "199001011234"),
+        (
+            "Existing",
+            functions.hash_value("exist@example.com"),
+            functions.hash_value("secret"),
+            functions.hash_value("199001011234"),
+        ),
     )
     conn.commit()
     conn.close()
@@ -198,6 +212,38 @@ def test_admin_upload_existing_user_only_saves_pdf(tmp_path, monkeypatch):
         response = client.post("/admin", data=data, content_type="multipart/form-data")
         assert response.status_code == 200
         assert response.get_json()["status"] == "success"
+
+
+def test_user_create_hashes_password(tmp_path, monkeypatch):
+    db_path = setup_db(tmp_path, monkeypatch)
+
+    # Lägg till pending user
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO pending_users (email, username, personnummer, pdf_path) VALUES (?, ?, ?, ?)",
+        (
+            functions.hash_value("user@example.com"),
+            "User",
+            functions.hash_value("199001011234"),
+            "doc.pdf",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    assert functions.user_create_user("mypassword", "199001011234")
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT password FROM users WHERE personnummer = ?",
+        (functions.hash_value("199001011234"),),
+    )
+    row = cursor.fetchone()
+    conn.close()
+    assert row is not None
+    assert row[0] == functions.hash_value("mypassword")
 
 
 def test_logout_clears_user_session(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- return user signup link in admin API after creating a pending user
- show the signup link in the admin UI
- test that user passwords are stored salted and hashed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a89ae98188832da649640c29645728