### PR TITLE
Hash sensitive fields

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from flask import (
 )
 from smtplib import SMTP
 import functions
-from functions import normalize_personnummer
+from functions import normalize_personnummer, hash_value
 import os
 import time
 from werkzeug.utils import secure_filename
@@ -29,7 +29,7 @@ ALLOWED_MIMES = {'application/pdf'}
 
 
 def save_pdf_for_user(pnr: str, file_storage) -> str:
-    """Spara PDF i uploads/<pnr>/ och returnera relativ sökväg (t.ex. 'uploads/199001011234/12345_cv.pdf')."""
+    """Spara PDF i uploads/<hash(pnr)>/ och returnera relativ sökväg."""
     if file_storage.filename == '':
         raise ValueError("Ingen fil vald.")
 
@@ -43,7 +43,8 @@ def save_pdf_for_user(pnr: str, file_storage) -> str:
         raise ValueError("Filen verkar inte vara en giltig PDF.")
 
     pnr_norm = normalize_personnummer(pnr)
-    user_dir = os.path.join(app.config['UPLOAD_ROOT'], pnr_norm)
+    pnr_hash = hash_value(pnr_norm)
+    user_dir = os.path.join(app.config['UPLOAD_ROOT'], pnr_hash)
     os.makedirs(user_dir, exist_ok=True)
 
     base = secure_filename(file_storage.filename)
@@ -59,17 +60,16 @@ def save_pdf_for_user(pnr: str, file_storage) -> str:
     rel_path = os.path.relpath(abs_path, APP_ROOT).replace('\\', '/')
     return rel_path
 
-@app.route('/create_user/<personnummer>', methods=['POST', 'GET'])
-def create_user(personnummer):
-    pnr_norm = normalize_personnummer(personnummer)
+@app.route('/create_user/<pnr_hash>', methods=['POST', 'GET'])
+def create_user(pnr_hash):
     if request.method == 'POST':
         password = request.form['password']
-        print(f"Skapar användare med personnummer: {pnr_norm} och lösenord: {password}")
-        functions.user_create_user(password, pnr_norm)
+        print(f"Skapar användare med hash: {pnr_hash} och lösenord: {password}")
+        functions.user_create_user(password, pnr_hash)
         return redirect('/login')
     elif request.method == 'GET':
-        if functions.check_pending_user(pnr_norm):
-            return render_template('create_user.html', personnummer=pnr_norm)
+        if functions.check_pending_user_hash(pnr_hash):
+            return render_template('create_user.html')
         else:
             return "Error: User not found"
 
@@ -85,7 +85,7 @@ def login():
         password = request.form['password']
         if functions.check_personnummer_password(personnummer, password):
             session['user_logged_in'] = True
-            session['personnummer'] = personnummer
+            session['personnummer'] = hash_value(personnummer)
             return redirect('/dashboard')
         else:
             return (
@@ -100,12 +100,8 @@ def dashboard():
     """Visa alla PDF:er för den inloggade användaren."""
     if not session.get('user_logged_in'):
         return redirect('/login')
-    pnr = session.get('personnummer')
-    try:
-        pnr_norm = normalize_personnummer(pnr)
-    except Exception:
-        return redirect('/login')
-    user_dir = os.path.join(app.config['UPLOAD_ROOT'], pnr_norm)
+    pnr_hash = session.get('personnummer')
+    user_dir = os.path.join(app.config['UPLOAD_ROOT'], pnr_hash)
     pdfs = []
     if os.path.isdir(user_dir):
         pdfs = [f for f in os.listdir(user_dir) if f.lower().endswith('.pdf')]
@@ -116,12 +112,8 @@ def dashboard():
 def download_pdf(filename):
     if not session.get('user_logged_in'):
         return redirect('/login')
-    pnr = session.get('personnummer')
-    try:
-        pnr_norm = normalize_personnummer(pnr)
-    except Exception:
-        return redirect('/login')
-    user_dir = os.path.join(app.config['UPLOAD_ROOT'], pnr_norm)
+    pnr_hash = session.get('personnummer')
+    user_dir = os.path.join(app.config['UPLOAD_ROOT'], pnr_hash)
     return send_from_directory(user_dir, filename, as_attachment=True)
 
 @app.route('/admin', methods=['POST', 'GET'])
@@ -150,7 +142,14 @@ def admin():
                     )
 
                 if functions.admin_create_user(email, username, personnummer, pdf_path):
-                    return jsonify({'status': 'success', 'message': 'User created successfully'})
+                    link = f"/create_user/{hash_value(personnummer)}"
+                    return jsonify(
+                        {
+                            'status': 'success',
+                            'message': 'User created successfully',
+                            'link': link,
+                        }
+                    )
                 else:
                     return jsonify({'status': 'error', 'message': 'User already exists'}), 409
             except ValueError as ve:

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -18,10 +18,14 @@
   const ALLOWED_MIME = 'application/pdf';
 
   // --- Hjälpmeddelanden ---
-  function showMessage(type, text) {
+  function showMessage(type, text, isHtml = false) {
     result.style.display = 'block';
     result.className = `message ${type}`;
-    result.textContent = text;
+    if (isHtml) {
+      result.innerHTML = text;
+    } else {
+      result.textContent = text;
+    }
   }
   function hideMessage() {
     result.style.display = 'none';
@@ -110,7 +114,10 @@
       }
 
       if (res.ok && data && data.status === 'success') {
-        showMessage('success', 'Användare skapad.');
+        const msg = data.link
+          ? `Användare skapad. Länk: <a href="${data.link}">${data.link}</a>`
+          : 'Användare skapad.';
+        showMessage('success', msg, !!data.link);
         form.reset();
       } else {
         const msg =


### PR DESCRIPTION
## Summary
- return user signup link in admin API after creating a pending user
- show the signup link in the admin UI
- test that user passwords are stored salted and hashed
- hash personal numbers in signup links and update account creation to consume the hashed value

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a89ae98188832da649640c29645728