### PR TITLE
Add placeholder license page and show during user creation

### DIFF
--- a/main.py
+++ b/main.py
@@ -78,6 +78,11 @@ def home():
     return render_template('index.html')
 
 
+@app.route('/license', methods=['GET'])
+def license():
+    return render_template('license.html')
+
+
 @app.route('/login', methods=['GET', 'POST'])
 def login():
     if request.method == 'POST':

--- a/templates/create_user.html
+++ b/templates/create_user.html
@@ -7,4 +7,6 @@
         <br>
         <input type="submit" value="Create User">
     </form>
+    <p>Please review the license below before creating your account.</p>
+    <iframe src="{{ url_for('license') }}" width="100%" height="300" title="License"></iframe>
 {% endblock %}

--- a/templates/license.html
+++ b/templates/license.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>License</h2>
+<p>This page will contain the license agreement in the future.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add Flask route and template for placeholder license agreement
- Display license content on user creation page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9e27b3310832d88b1d874e1bc7609