### PR TITLE
Add placeholder license page and show during user creation

### DIFF
--- a/main.py
+++ b/main.py
@@ -78,6 +78,11 @@ def home():
     return render_template('index.html')
 
 
+@app.route('/license', methods=['GET'])
+def license():
+    return render_template('license.html')
+
+
 @app.route('/login', methods=['GET', 'POST'])
 def login():
     if request.method == 'POST':

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -99,3 +99,19 @@ small.hint {
     display: block;
     margin-top: 6px;
 }
+
+a.license-link {
+    display: inline-block;
+    margin-top: 10px;
+    padding: 8px 12px;
+    background: #f8f9fa;
+    border: 1px solid #007bff;
+    border-radius: 4px;
+    color: #007bff;
+    text-decoration: none;
+}
+
+a.license-link:hover {
+    background: #007bff;
+    color: #fff;
+}

--- a/templates/create_user.html
+++ b/templates/create_user.html
@@ -7,4 +7,6 @@
         <br>
         <input type="submit" value="Create User">
     </form>
+    <p>Please review the license agreement before creating your account:</p>
+    <a href="{{ url_for('license') }}" class="license-link" target="_blank">View License Agreement</a>
 {% endblock %}

--- a/templates/license.html
+++ b/templates/license.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>License</h2>
+<p>This page will contain the license agreement in the future.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add Flask route and template for placeholder license agreement
- Display license content via styled link on user creation page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9e27b3310832d88b1d874e1bc7609