### PR TITLE
Add WSGI entrypoint

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,5 @@
+from main import app as application
+
+if __name__ == "__main__":
+    # This allows running the app with `python wsgi.py`
+    application.run()


### PR DESCRIPTION
## Summary
- add simple WSGI entry point so the Flask app can be served by WSGI servers
- refactor app initialization for production with `create_app` and environment-based debug/test user

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ade204287c832d8bacb89b6d0f9285