### PR TITLE
Enhance credential security and database persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This web application manages the issuance and storage of course certificates. It
 
 * **SQLite database** – User metadata and pending registrations are stored in a local SQLite database file.
 * **File system** – Certificates reside in an `uploads/<personnummer>/` directory structure. The application only accepts PDF files to prevent accidental uploads of other formats.
+* **Hashed credentials** – Passwords are hashed with a per-user salt using PBKDF2 via Werkzeug, while personal numbers and emails are deterministically hashed with a global salt so sensitive data isn't stored in plain text.
 
 This description focuses on the internal workflow and division of responsibilities. Operational details such as installation or deployment are intentionally omitted.
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -64,7 +64,7 @@ def setup_user(tmp_path, monkeypatch):
         (
             "Test",
             functions.hash_value("test@example.com"),
-            functions.hash_value("secret"),
+            functions.hash_password("secret"),
             functions.hash_value("199001011234"),
         ),
     )
@@ -168,7 +168,7 @@ def test_admin_upload_creates_pending_user(tmp_path, monkeypatch, pnr_input):
 
     pdf_bytes = b"%PDF-1.4 test"
     data = {
-        "email": "liam@suorsa.se",
+        "email": "new@example.com",
         "username": "New User",
         "personnummer": pnr_input,
         "pdf": (io.BytesIO(pdf_bytes), "doc.pdf"),
@@ -274,7 +274,7 @@ def test_admin_upload_existing_user_only_saves_pdf(tmp_path, monkeypatch):
         (
             "Existing",
             functions.hash_value("exist@example.com"),
-            functions.hash_value("secret"),
+            functions.hash_password("secret"),
             functions.hash_value("199001011234"),
         ),
     )
@@ -328,7 +328,7 @@ def test_user_create_hashes_password(tmp_path, monkeypatch):
     row = cursor.fetchone()
     conn.close()
     assert row is not None
-    assert row[0] == functions.hash_value("mypassword")
+    assert functions.verify_password(row[0], "mypassword")
 
 
 def test_logout_clears_user_session(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- harden personal data hashing with PBKDF2 and store SQLite database on disk for persistence
- introduce per-user salted password hashing using Werkzeug and update authentication logic
- document hashing approach and update tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b200ecbe90832daa59088f9cb7bd84