### PR TITLE
Improve security of admin email flow and salt loading

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -5,8 +5,15 @@ import os
 import re
 from datetime import datetime
 from werkzeug.security import generate_password_hash, check_password_hash
+from dotenv import load_dotenv
 
 logger = logging.getLogger(__name__)
+
+# Ensure environment variables from a .env file are loaded before accessing
+# configuration such as ``HASH_SALT``. Without this, a missing ``HASH_SALT``
+# would silently fall back to the insecure default below.
+load_dotenv()
+
 # Base directory to store the SQLite database so data persists across restarts.
 APP_ROOT = os.path.abspath(os.path.dirname(__file__))
 DB_PATH = os.path.join(APP_ROOT, "database.db")
@@ -14,6 +21,10 @@ DB_PATH = os.path.join(APP_ROOT, "database.db")
 # Global salt used for deterministic hashing of personal data like email and
 # personnummer. Must remain constant or stored data cannot be retrieved.
 SALT = os.getenv("HASH_SALT", "static_salt")
+if SALT == "static_salt":
+    logger.warning(
+        "Using default HASH_SALT; set HASH_SALT in environment for stronger security"
+    )
 
 
 def hash_value(value: str) -> str:

--- a/main.py
+++ b/main.py
@@ -234,7 +234,13 @@ def admin():
                         send_creation_email(email, link)
                     except RuntimeError as e:
                         logger.error("Failed to send creation email to %s", email)
-                        return redirect('/error')
+                        return (
+                            jsonify({
+                                'status': 'error',
+                                'message': str(e),
+                            }),
+                            500,
+                        )
                     logger.info("Admin created user %s", personnummer)
                     return jsonify(
                         {


### PR DESCRIPTION
## Summary
- Ensure environment variables are loaded before hashing so HASH_SALT from .env is respected, warning if default salt is used
- Return JSON 500 when SMTP authentication fails during admin user creation instead of redirecting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b208a65578832db35010dbe19297ba