### PR TITLE
fix: lowercase ghcr repository owner

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,8 +19,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set lower-case repository owner
+        run: echo "REPOSITORY_OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
       - uses: docker/build-push-action@v5
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/jk-utbildnings-intyg:latest
+          tags: ghcr.io/${{ env.REPOSITORY_OWNER_LC }}/jk-utbildnings-intyg:latest

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -19,7 +19,7 @@ The app will be available on http://localhost:8000.
 
 ## Production deployment
 
-Images are built and pushed to GHCR on every push to the `main` branch. The latest image can be pulled and started as follows (replace `OWNER` with your GitHub username or organisation):
+Images are built and pushed to GHCR on every push to the `main` branch. The latest image can be pulled and started as follows (replace `OWNER` with your GitHub username or organisation in lowercase):
 
 ```bash
 docker pull ghcr.io/OWNER/jk-utbildnings-intyg:latest


### PR DESCRIPTION
## Summary
- ensure GitHub Actions workflow pushes container images with a lowercase owner
- document that GHCR tags require the owner to be lowercase

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b20da4df00832d8e946549706d979d