### PR TITLE
Add volume support for SQLite database

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -27,10 +27,13 @@ docker pull ghcr.io/mr-cool08/jk-utbildnings-intyg:latest
 docker run -d --env-file .env -p 8000:8000 ghcr.io/mr-cool08/jk-utbildnings-intyg:latest
 ```
 
-This exposes the application on port 8000 and loads environment variables from your local `.env` file. Mount a volume for persistent uploads if needed:
+This exposes the application on port 8000 and loads environment variables from your local `.env` file. Mount volumes for persistent uploads and the SQLite database if needed:
 
 ```bash
-docker run -d --env-file .env -p 8000:8000 -v $(pwd)/uploads:/app/uploads ghcr.io/OWNER/jk-utbildnings-intyg:latest
+docker run -d --env-file .env -p 8000:8000 \
+  -v $(pwd)/uploads:/app/uploads \
+  -v $(pwd)/data:/data \
+  ghcr.io/OWNER/jk-utbildnings-intyg:latest
 ```
 
 Alternatively, edit `docker-compose.yml` to reference `ghcr.io/OWNER/jk-utbildnings-intyg:latest` as the image and run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,13 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy project
 COPY . .
 
-# Configure port
-ENV PORT=8000
+# Ensure runtime directories exist and declare them as volumes for persistence
+RUN mkdir -p /data /app/uploads
+VOLUME ["/data", "/app/uploads"]
+
+# Configure port and default database location
+ENV PORT=8000 \
+    DB_PATH=/data/database.db
 EXPOSE 8000
 
 # Run the application with Gunicorn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,8 @@ services:
       - "8000:8000"
     env_file:
       - .env
+    environment:
+      DB_PATH: /data/database.db
     volumes:
       - ./uploads:/app/uploads
+      - ./data:/data


### PR DESCRIPTION
## Summary
- make database path configurable via `DB_PATH` environment variable
- ensure database directory exists when initializing
- add Docker volume mounts and default `/data` database location with docs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2115fd344832d884e5bf4c6ca2bb0