### PR TITLE
Simplify deployment instructions

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -5,7 +5,6 @@ This project ships with a Docker setup and a GitHub Actions workflow that automa
 ## Prerequisites
 
 - Docker or Docker Desktop installed
-- A `.env` file containing the required environment variables such as `secret_key`, `smtp_server`, `smtp_user`, etc.
 
 ## Local development
 
@@ -19,12 +18,11 @@ The app will be available on http://localhost:8000.
 
 ## Production deployment
 
-Images are built and pushed to GHCR and Docker Hub on every push to the `main` branch. The latest image can be pulled and started as follows (replace `OWNER` with your GitHub username or organisation in lowercase and `DOCKERHUB_USER` with your Docker Hub username):
+Images are built and pushed to GHCR and Docker Hub on every push to the `main` branch. Run the latest image as follows:
 
 ```bash
 docker pull ghcr.io/mr-cool08/jk-utbildnings-intyg:latest
 
-# start the container with persistent named volumes
 docker run -d -p 8000:8000 \
   -v env_data:/config \
   -v uploads_data:/app/uploads \
@@ -33,13 +31,7 @@ docker run -d -p 8000:8000 \
   ghcr.io/mr-cool08/jk-utbildnings-intyg:latest
 ```
 
-The `docker run` command above creates the four volumes automatically if they do not already exist. Populate the configuration volume with your `.env` file before the first run:
-
-```bash
-docker run --rm -v env_data:/config -v $(pwd)/.env:/tmp/.env busybox cp /tmp/.env /config/.env
-```
-
-After this, the application is available on port 8000.
+The volumes are created automatically if they do not exist. On first start the container copies `.example.env` into the `env_data` volume as `.env`. Edit this file and restart the container to update environment variables.
 
 ## Kör med GitHub Container Registry
 Replace the image name with `ghcr.io/OWNER/jk-utbildnings-intyg:latest` in the command above to run your own published image.
@@ -60,4 +52,3 @@ Alternatively, edit `docker-compose.yml` to reference `ghcr.io/OWNER/jk-utbildni
 ```bash
 docker compose up -d
 ```
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy project
 COPY . .
 
-# Ensure runtime directories exist and declare them as volumes for persistence
-RUN mkdir -p /data /app/uploads /app/logs /config
+# Ensure runtime directories exist, seed configuration volume, and declare them as volumes for persistence
+RUN mkdir -p /data /app/uploads /app/logs /config \
+    && cp .example.env /config/.env
 VOLUME ["/data", "/app/uploads", "/app/logs", "/config"]
 
 # Configure port and default database location


### PR DESCRIPTION
## Summary
- streamline deployment guide to only require `docker pull` and `docker run`
- document automatic seeding of `.env` file from `.example.env`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b222990064832daf118ceac0f60051