### PR TITLE
fix: use packaged Swedish dictionary for cspell

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,14 +1,8 @@
 {
   "version": "0.2",
   "language": "sv",
+  "import": ["cspell-dict-sv"],
   "dictionaries": ["sv"],
-  "dictionaryDefinitions": [
-    {
-      "name": "sv",
-      "path": "cspell-dict-sv/sv/dictionary.txt",
-      "addWords": true
-    }
-  ],
   "useGitignore": true,
   "ignorePaths": [
     "node_modules",


### PR DESCRIPTION
## Summary
- use cspell-dict-sv package instead of missing local dictionary

## Testing
- `pytest`
- `npx cspell --no-progress --config .cspell.json README.md` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cspell)*

------
https://chatgpt.com/codex/tasks/task_e_68b36de71408832dbadb58751e936e5f