### PR TITLE
feat: cache certificate verification results

### DIFF
--- a/app.py
+++ b/app.py
@@ -313,6 +313,27 @@ def admin():
         return redirect('/login_admin')
     logger.debug("Rendering admin page")
     return render_template('admin.html')
+
+
+@app.route('/verify_certificate/<personnummer>', methods=['GET'])
+def verify_certificate_route(personnummer):
+    """Allow an admin to verify whether a user's certificate is confirmed.
+
+    Uses a cached lookup to avoid repeated database queries for the same
+    ``personnummer``. Returns a JSON response indicating the verification
+    status. If the certificate isn't verified, an informative message is sent
+    back to the administrator.
+    """
+    if not session.get('admin_logged_in'):
+        logger.warning("Unauthorized certificate verification attempt")
+        return redirect('/login_admin')
+
+    if functions.verify_certificate(personnummer):
+        return jsonify({'status': 'success', 'verified': True})
+    return jsonify({
+        'status': 'error',
+        'message': "User's certificate is not verified",
+    }), 404
 @app.route("/error")
 def error():
     # This will cause a 500 Internal Server Error

--- a/tests/test_certificate_verification.py
+++ b/tests/test_certificate_verification.py
@@ -1,0 +1,43 @@
+import os
+import sqlite3
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import app
+import functions
+
+
+def setup_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    real_connect = sqlite3.connect
+    calls = {"count": 0}
+
+    def connect_stub(_):
+        calls["count"] += 1
+        return real_connect(db_path)
+
+    monkeypatch.setattr(functions.sqlite3, "connect", connect_stub)
+    monkeypatch.setattr(app.functions, "sqlite3", functions.sqlite3)
+    app.app.secret_key = "test-secret"
+    functions.create_database()
+    calls["count"] = 0
+    return db_path, calls
+
+
+def test_verify_certificate_caching_and_message(tmp_path, monkeypatch):
+    _, calls = setup_db(tmp_path, monkeypatch)
+    functions.verify_certificate.cache_clear()
+
+    assert not functions.verify_certificate("19900101-1234")
+    assert not functions.verify_certificate("19900101-1234")
+    assert calls["count"] == 1
+
+    with app.app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["admin_logged_in"] = True
+        response = client.get("/verify_certificate/19900101-1234")
+        assert response.status_code == 404
+        assert b"not verified" in response.data.lower()
+        # No additional DB call due to caching
+        assert calls["count"] == 1


### PR DESCRIPTION
## Summary
- cache certificate verification lookups to avoid repeated DB hits
- expose admin endpoint to report if a user's certificate has been verified
- test verification caching and messaging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3755b5578832daa05cd621b57a042