### PR TITLE
Improve account creation page and email appearance

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from flask import (
     redirect,
     send_from_directory,
     current_app,
+    url_for,
 
 )
 from smtplib import SMTP, SMTPAuthenticationError, SMTPException
@@ -105,12 +106,11 @@ def send_creation_email(to_email: str, link: str) -> None:
     msg.set_content(
         f"""
         <html>
-            <body style='font-family: Arial, sans-serif; line-height: 1.4;'>
-                <h2>Create your account</h2>
-                <p>Please create your password using the link below:</p>
-                <p><a href='{link}' style='background:#007bff;color:#fff;padding:10px 15px;text-decoration:none;border-radius:4px;'>Create account</a></p>
-                <p style='margin-top:20px;'>If the button above does not work, copy and paste this link into your browser:</p>
-                <p>{link}</p>
+            <body style='font-family: Arial, sans-serif; line-height: 1.5;'>
+                <p>Hello,</p>
+                <p>Please create your account by visiting this link:</p>
+                <p><a href="{link}">{link}</a></p>
+                <p>If you did not request this email, you can ignore it.</p>
             </body>
         </html>
         """,
@@ -320,7 +320,8 @@ def admin():
                     )
 
                 if functions.admin_create_user(email, username, personnummer, pdf_path):
-                    link = f"/create_user/{functions.hash_value(personnummer)}"
+                    pnr_hash = functions.hash_value(personnummer)
+                    link = url_for('create_user', pnr_hash=pnr_hash, _external=True)
                     # Skicka e-post med länken för att skapa lösenord
                     try:
                         send_creation_email(email, link)

--- a/app.py
+++ b/app.py
@@ -22,6 +22,7 @@ import functions
 import os, ssl, logging
 from smtplib import SMTP, SMTPException, SMTPAuthenticationError, SMTPServerDisconnected
 from email.message import EmailMessage
+from email import policy
 
 
 APP_ROOT = os.path.abspath(os.path.dirname(__file__))
@@ -97,11 +98,24 @@ def send_creation_email(to_email: str, link: str) -> None:
     if not (smtp_server and smtp_user and smtp_password):
         raise RuntimeError("Saknar env: smtp_server, smtp_user eller smtp_password")
 
-    msg = EmailMessage()
+    msg = EmailMessage(policy=policy.SMTP.clone(max_line_length=1000))
     msg["Subject"] = "Create your account"
     msg["From"] = smtp_user
     msg["To"] = to_email
-    msg.set_content(f"Please create your password using the link below:\n{link}\n")
+    msg.set_content(
+        f"""
+        <html>
+            <body style='font-family: Arial, sans-serif; line-height: 1.4;'>
+                <h2>Create your account</h2>
+                <p>Please create your password using the link below:</p>
+                <p><a href='{link}' style='background:#007bff;color:#fff;padding:10px 15px;text-decoration:none;border-radius:4px;'>Create account</a></p>
+                <p style='margin-top:20px;'>If the button above does not work, copy and paste this link into your browser:</p>
+                <p>{link}</p>
+            </body>
+        </html>
+        """,
+        subtype="html",
+    )
 
     context = ssl.create_default_context()
 

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -180,3 +180,28 @@ footer {
     background: #333;
     color: #fff;
 }
+
+/* Account creation page */
+.create-account {
+    max-width: 400px;
+    margin: 0 auto;
+}
+
+.create-account h2 {
+    text-align: center;
+    margin-bottom: 20px;
+}
+
+.create-account form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.create-account button {
+    width: 100%;
+}
+
+.create-account .license-note {
+    margin-top: 16px;
+}

--- a/templates/create_user.html
+++ b/templates/create_user.html
@@ -1,12 +1,13 @@
 {% extends "base.html" %}
 {% block content %}
-    <h2>Create User</h2>
-    <form method="POST">
-        <label for="password">Password:</label>
-        <input type="password" id="password" name="password" required>
-        <br>
-        <input type="submit" value="Create User">
-    </form>
-    <p>Please review the license agreement before creating your account:</p>
-    <a href="{{ url_for('license') }}" class="license-link" target="_blank">View License Agreement</a>
+    <div class="create-account">
+        <h2>Create Account</h2>
+        <form method="POST">
+            <label for="password">Password:</label>
+            <input type="password" id="password" name="password" required>
+            <button type="submit">Create Account</button>
+        </form>
+        <p class="license-note">Please review the license agreement before creating your account:</p>
+        <a href="{{ url_for('license') }}" class="license-link" target="_blank">View License Agreement</a>
+    </div>
 {% endblock %}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -407,7 +407,7 @@ def test_create_user_route_moves_pending_user(tmp_path, monkeypatch):
     with app.app.test_client() as client:
         resp = client.get(f"/create_user/{pnr_hash}")
         assert resp.status_code == 200
-        assert b"Create User" in resp.data
+        assert b"Create Account" in resp.data
 
         resp = client.post(f"/create_user/{pnr_hash}", data={"password": "newpass"})
         assert resp.status_code == 302

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -184,7 +184,9 @@ def test_admin_upload_creates_pending_user(tmp_path, monkeypatch, pnr_input):
         assert response.status_code == 200
         resp_json = response.get_json()
         assert resp_json["status"] == "success"
-        expected_link = f"/create_user/{functions.hash_value(functions.normalize_personnummer(pnr_input))}"
+        expected_link = (
+            f"http://localhost/create_user/{functions.hash_value(functions.normalize_personnummer(pnr_input))}"
+        )
         assert resp_json["link"] == expected_link
 
     # Ensure an email was sent with the correct link


### PR DESCRIPTION
## Summary
- Style the account creation page with a centered container and button
- Send HTML formatted account creation emails with a styled call-to-action
- Update test to reflect new account creation page text

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4170e6de4832d83fd3a3834bdfdcb