### PR TITLE
Translate interface to Swedish

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,7 +89,7 @@ from email.message import EmailMessage
 logger = logging.getLogger(__name__)
 
 def send_creation_email(to_email: str, link: str) -> None:
-    """Skicka länk för att skapa lösenord via SMTP (STARTTLS på port 587)."""
+    """Send a password creation link via SMTP (STARTTLS on port 587)."""
 
     smtp_server = os.getenv("smtp_server")
     smtp_port = int(os.getenv("smtp_port", "587"))
@@ -100,17 +100,17 @@ def send_creation_email(to_email: str, link: str) -> None:
         raise RuntimeError("Saknar env: smtp_server, smtp_user eller smtp_password")
 
     msg = EmailMessage(policy=policy.SMTP.clone(max_line_length=1000))
-    msg["Subject"] = "Create your account"
+    msg["Subject"] = "Skapa ditt konto"
     msg["From"] = smtp_user
     msg["To"] = to_email
     msg.set_content(
         f"""
         <html>
             <body style='font-family: Arial, sans-serif; line-height: 1.5;'>
-                <p>Hello,</p>
-                <p>Please create your account by visiting this link:</p>
+                <p>Hej,</p>
+                <p>Skapa ditt konto genom att besöka denna länk:</p>
                 <p><a href="{link}">{link}</a></p>
-                <p>If you did not request this email, you can ignore it.</p>
+                <p>Om du inte begärde detta e-postmeddelande kan du ignorera det.</p>
             </body>
         </html>
         """,
@@ -120,7 +120,7 @@ def send_creation_email(to_email: str, link: str) -> None:
     context = ssl.create_default_context()
 
     try:
-        logger.debug("Skickar via %s:%s (STARTTLS) till %s", smtp_server, smtp_port, to_email)
+        logger.debug("Sending via %s:%s (STARTTLS) to %s", smtp_server, smtp_port, to_email)
 
         with SMTP(smtp_server, smtp_port) as smtp:
             # Vissa testdummies saknar ehlo(), så anropa bara om metoden finns
@@ -151,20 +151,20 @@ def send_creation_email(to_email: str, link: str) -> None:
             else:
                 smtp.sendmail(smtp_user, to_email, msg.as_string())
 
-        logger.info("Creation email skickat till %s", to_email)
+        logger.info("Creation email sent to %s", to_email)
 
     except SMTPAuthenticationError as exc:
-        logger.exception("SMTP-inloggning misslyckades för %s", smtp_user)
-        raise RuntimeError("SMTP login failed") from exc
+        logger.exception("SMTP login failed for %s", smtp_user)
+        raise RuntimeError("SMTP-inloggning misslyckades") from exc
     except SMTPServerDisconnected as exc:
-        logger.exception("Servern stängde anslutningen under SMTP-sessionen")
-        raise RuntimeError("Failed to send email") from exc
+        logger.exception("Server closed the connection during SMTP session")
+        raise RuntimeError("Det gick inte att skicka e-post") from exc
     except SMTPException as exc:
-        logger.exception("SMTP-fel vid sändning till %s", to_email)
-        raise RuntimeError("Failed to send email") from exc
+        logger.exception("SMTP error when sending to %s", to_email)
+        raise RuntimeError("Det gick inte att skicka e-post") from exc
     except OSError as exc:
-        logger.exception("Anslutningsfel mot e-postservern")
-        raise RuntimeError("Failed to connect to email server") from exc
+        logger.exception("Connection error to email server")
+        raise RuntimeError("Det gick inte att ansluta till e-postservern") from exc
 
 @app.context_processor
 def inject_flags():
@@ -226,7 +226,7 @@ def create_user(pnr_hash):
             return render_template('create_user.html')
         else:
             logger.warning("User hash %s not found during create_user", pnr_hash)
-            return "Error: User not found"
+            return "Fel: Användaren hittades inte"
 
 @app.route('/', methods=['GET'])
 def home():
@@ -258,7 +258,7 @@ def login():
         else:
             logger.warning("Invalid login for %s", personnummer)
             return (
-                render_template('user_login.html', error='Invalid credentials'),
+                render_template('user_login.html', error='Ogiltiga inloggningsuppgifter'),
                 401,
             )
     logger.debug("Rendering login page")
@@ -334,7 +334,7 @@ def admin():
                     return jsonify(
                         {
                             'status': 'success',
-                            'message': 'PDF uploaded for existing user',
+                            'message': 'PDF uppladdad för befintlig användare',
                         }
                     )
 
@@ -357,7 +357,7 @@ def admin():
                     return jsonify(
                         {
                             'status': 'success',
-                            'message': 'User created successfully',
+                            'message': 'Användare skapad',
                             'link': link,
                         }
                     )
@@ -372,7 +372,7 @@ def admin():
                 return (
                     jsonify({
                         'status': 'error',
-                        'message': 'Server error',
+                        'message': 'Serverfel',
                     }),
                     500,
                 )
@@ -404,7 +404,7 @@ def verify_certificate_route(personnummer):
         return jsonify({'status': 'success', 'verified': True})
     return jsonify({
         'status': 'error',
-        'message': "User's certificate is not verified",
+        'message': "Användarens certifikat är inte verifierat",
     }), 404
 @app.route("/error")
 def error():
@@ -425,13 +425,13 @@ def login_admin():
             return redirect('/admin')
         else:
             logger.warning("Invalid admin login attempt for %s", request.form['username'])
-            return jsonify({'status': 'error', 'message': 'Invalid credentials'})
+            return jsonify({'status': 'error', 'message': 'Ogiltiga inloggningsuppgifter'})
     elif request.method == 'GET':
         logger.debug("Rendering admin login page")
         return render_template('admin_login.html')
     else:
         logger.warning("Invalid request method %s to login_admin", request.method)
-        return jsonify({'status': 'error', 'message': 'Invalid request method', 'method': request.method})
+        return jsonify({'status': 'error', 'message': 'Ogiltig HTTP-metod', 'method': request.method})
 
 
 @app.route('/logout')

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -96,7 +96,7 @@
 
     // Skicka
     submitBtn.disabled = true;
-    submitBtn.textContent = 'Skapar...';
+        submitBtn.textContent = 'Skapar...';
 
     try {
       const res = await fetch('/admin', {
@@ -131,7 +131,7 @@
       // console.error(err);
     } finally {
       submitBtn.disabled = false;
-      submitBtn.textContent = 'Create pending user';
+        submitBtn.textContent = 'Skapa användare';
     }
   });
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,32 +1,32 @@
 {% extends 'base.html' %}
-{% block title %}Admin — Create User{% endblock %}
+{% block title %}Admin — Skapa användare{% endblock %}
 {% block content %}
-    <h1>Admin — Create User</h1>
-    <p>Use this form to add a pending user. Fields are required. When the POST succeeds the server will insert into <code>pending_users</code>.</p>
+    <h1>Admin — Skapa användare</h1>
+    <p>Använd detta formulär för att lägga till en väntande användare. Fälten är obligatoriska. När POST lyckas lägger servern in posten i <code>pending_users</code>.</p>
 
     <form id="adminForm" autocomplete="off" enctype="multipart/form-data" method="post">
-        <label for="email">Email</label>
+        <label for="email">E-post</label>
         <input id="email" name="email" type="email" required placeholder="user@example.com" />
 
-        <label for="username">Username</label>
-        <input id="username" name="username" type="text" required placeholder="Full name or username" />
+        <label for="username">Användarnamn</label>
+        <input id="username" name="username" type="text" required placeholder="Fullständigt namn eller användarnamn" />
 
         <div class="row">
             <div class="col">
                 <label for="personnummer">Personnummer</label>
-                <!-- Simple pattern: 6-12 digits, allows formats like YYMMDDNNNN or YYYYMMDDNNNN -->
-                <input id="personnummer" name="personnummer" type="text" required pattern="[\d\-]{6,14}" placeholder="YYYYMMDDNNNN or YYMMDDNNNN" />
-                <small class="hint">Allowed characters: digits and hyphen. Example: 19900101-1234</small>
+                <!-- Enkelt mönster: 6-12 siffror, tillåter format som YYMMDDNNNN eller YYYYMMDDNNNN -->
+                <input id="personnummer" name="personnummer" type="text" required pattern="[\\d\\-]{6,14}" placeholder="ÅÅÅÅMMDDNNNN eller ÅÅMMDDNNNN" />
+                <small class="hint">Tillåtna tecken: siffror och bindestreck. Exempel: 19900101-1234</small>
             </div>
 
             <div class="col">
-                <label for="pdf">Upload PDF</label>
+                <label for="pdf">Ladda upp PDF</label>
                 <input id="pdf" name="pdf" type="file" accept="application/pdf" required />
-                <small class="hint">Only PDF files are allowed.</small>
+                <small class="hint">Endast PDF-filer är tillåtna.</small>
             </div>
         </div>
 
-        <button id="submitBtn" type="submit">Create pending user</button>
+        <button id="submitBtn" type="submit">Skapa användare</button>
 
         <div id="result" class="message" style="display:none"></div>
     </form>

--- a/templates/admin_login.html
+++ b/templates/admin_login.html
@@ -1,13 +1,12 @@
 {% extends 'base.html' %}
-{% block title %}Admin Login{% endblock %}
+{% block title %}Administratörsinloggning{% endblock %}
 {% block content %}
-    <h1>Admin Login</h1>
+    <h1>Administratörsinloggning</h1>
     <form action="/login_admin" method="POST">
-        <label for="username">Username:</label>
+        <label for="username">Användarnamn:</label>
         <input type="text" id="username" name="username" required>
-        <label for="password">Password:</label>
+        <label for="password">Lösenord:</label>
         <input type="password" id="password" name="password" required>
-        <button type="submit">Login</button>
+        <button type="submit">Logga in</button>
     </form>
 {% endblock %}
-    

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="sv">
 <head>
     <meta charset="UTF-8">
-    <title>{% block title %}My Site{% endblock %}</title>
+    <title>{% block title %}Min webbplats{% endblock %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/base.css') }}">
     {% block head %}{% endblock %}
 </head>
 <body>
     <nav>
-        <a class="brand" href="/">Home</a>
+        <a class="brand" href="/">Hem</a>
         <div class="nav-links">
             {% if session.get('user_logged_in') %}
-                <a href="/dashboard">Dashboard</a>
-                <a href="/logout">Logout</a>
+                <a href="/dashboard">Översikt</a>
+                <a href="/logout">Logga ut</a>
             {% elif session.get('admin_logged_in') %}
                 <a href="/admin">Admin</a>
-                <a href="/logout">Logout</a>
+                <a href="/logout">Logga ut</a>
             {% else %}
-                <a href="/login">User Login</a>
+                <a href="/login">Användarinloggning</a>
             {% endif %}
         </div>
     </nav>

--- a/templates/create_user.html
+++ b/templates/create_user.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}
 {% block content %}
     <div class="create-account">
-        <h2>Create Account</h2>
+        <h2>Skapa konto</h2>
         <form method="POST">
-            <label for="password">Password:</label>
+            <label for="password">Lösenord:</label>
             <input type="password" id="password" name="password" required>
-            <button type="submit">Create Account</button>
+            <button type="submit">Skapa konto</button>
         </form>
-        <p class="license-note">Please review the license agreement before creating your account:</p>
-        <a href="{{ url_for('license') }}" class="license-link" target="_blank">View License Agreement</a>
+        <p class="license-note">Vänligen läs licensavtalet innan du skapar ditt konto:</p>
+        <a href="{{ url_for('license') }}" class="license-link" target="_blank">Visa licensavtal</a>
     </div>
 {% endblock %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,11 +1,11 @@
 {% extends 'base.html' %}
-{% block title %}Dashboard{% endblock %}
+{% block title %}Översikt{% endblock %}
 {% block head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
 {% endblock %}
 {% block content %}
 <section class="dashboard">
-    <h1>Your PDFs</h1>
+    <h1>Dina PDF:er</h1>
     {% if pdfs %}
     <ul class="pdf-list">
         {% for pdf in pdfs %}
@@ -13,7 +13,7 @@
         {% endfor %}
     </ul>
     {% else %}
-    <p>No PDFs uploaded.</p>
+    <p>Inga PDF:er uppladdade.</p>
     {% endif %}
 </section>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,26 +1,26 @@
 {% extends 'base.html' %}
-{% block title %}Welcome{% endblock %}
+{% block title %}Välkommen{% endblock %}
 {% block content %}
 <div class="hero">
-    <h1>Manage Training Certificates Easily</h1>
-    <p>JK Utbildnings Intyg helps you store and access certificates wherever you are.</p>
+    <h1>Hantera utbildningsintyg enkelt</h1>
+    <p>JK Utbildnings Intyg hjälper dig att lagra och komma åt intyg var du än är.</p>
     <div class="actions">
-        <a class="btn" href="/login">User Login</a>
+        <a class="btn" href="/login">Användarinloggning</a>
     </div>
 </div>
 
 <section class="features">
     <div class="feature">
-        <h2>Organize</h2>
-        <p>Keep all your training records in one secure place.</p>
+        <h2>Organisera</h2>
+        <p>Spara alla dina utbildningsintyg på ett ställe.</p>
     </div>
     <div class="feature">
-        <h2>Verify</h2>
-        <p>Share and verify certificates with ease.</p>
+        <h2>Verifiera</h2>
+        <p>Dela och verifiera intyg enkelt.</p>
     </div>
     <div class="feature">
-        <h2>Access</h2>
-        <p>Log in from any device to view your credentials.</p>
+        <h2>Åtkomst</h2>
+        <p>Logga in från valfri enhet för att se dina intyg.</p>
     </div>
 </section>
 {% endblock %}

--- a/templates/license.html
+++ b/templates/license.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
 {% block content %}
-<h2>License</h2>
-<p>This page will contain the license agreement in the future.</p>
+<h2>Licens</h2>
+<p>Denna sida kommer att innehålla licensavtalet i framtiden.</p>
 {% endblock %}

--- a/templates/user_login.html
+++ b/templates/user_login.html
@@ -1,13 +1,13 @@
 {% extends 'base.html' %}
-{% block title %}User Login{% endblock %}
+{% block title %}Användarinloggning{% endblock %}
 {% block content %}
-    <h1>User Login</h1>
+    <h1>Användarinloggning</h1>
     {% if error %}<p class="error">{{ error }}</p>{% endif %}
     <form action="/login" method="POST">
         <label for="personnummer">Personnummer:</label>
         <input type="text" id="personnummer" name="personnummer" required>
-        <label for="password">Password:</label>
+        <label for="password">Lösenord:</label>
         <input type="password" id="password" name="password" required>
-        <button type="submit">Login</button>
+        <button type="submit">Logga in</button>
     </form>
 {% endblock %}

--- a/templates/view_pdf.html
+++ b/templates/view_pdf.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% block title %}View PDF{% endblock %}
+{% block title %}Visa PDF{% endblock %}
 {% block head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/pdf_viewer.css') }}">
 {% endblock %}
@@ -8,5 +8,5 @@
 <div class="pdf-container">
     <iframe src="{{ pdf_url }}" title="{{ filename }}" frameborder="0"></iframe>
 </div>
-<p><a href="{{ url_for('download_pdf', filename=filename) }}">Download PDF</a></p>
+<p><a href="{{ url_for('download_pdf', filename=filename) }}">Ladda ner PDF</a></p>
 {% endblock %}

--- a/tests/test_certificate_verification.py
+++ b/tests/test_certificate_verification.py
@@ -38,6 +38,6 @@ def test_verify_certificate_caching_and_message(tmp_path, monkeypatch):
             sess["admin_logged_in"] = True
         response = client.get("/verify_certificate/19900101-1234")
         assert response.status_code == 404
-        assert b"not verified" in response.data.lower()
+        assert "inte verifierat" in response.get_data(as_text=True).lower()
         # No additional DB call due to caching
         assert calls["count"] == 1

--- a/tests/test_email_env.py
+++ b/tests/test_email_env.py
@@ -60,6 +60,6 @@ def test_send_creation_email_uses_env_credentials(monkeypatch):
     msg = sent["message"]
     assert msg["From"] == env_values["smtp_user"]
     assert msg["To"] == "liamsuorsa08@gmail.com"
-    assert msg["Subject"] == "Create your account"
+    assert msg["Subject"] == "Skapa ditt konto"
     # Innehållet ska innehålla länken
     assert link in msg.get_content()


### PR DESCRIPTION
## Summary
- Localized user and admin flows to Swedish, including navigation, forms and landing content
- Sent account creation emails in Swedish while keeping log messages in English
- Updated tests for Swedish responses and decoded email content

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b41d1bbc98832da8852ed5d27f472b