### PR TITLE
Add robots.txt to block crawlers

### DIFF
--- a/app.py
+++ b/app.py
@@ -214,6 +214,11 @@ def save_pdf_for_user(pnr: str, file_storage) -> str:
     rel_path = os.path.relpath(abs_path, APP_ROOT).replace('\\', '/')
     return rel_path
 
+@app.route('/robots.txt')
+def robots_txt():
+    """Serve robots.txt to disallow all crawlers."""
+    return send_from_directory(app.static_folder, 'robots.txt', mimetype='text/plain')
+
 @app.route('/create_user/<pnr_hash>', methods=['POST', 'GET'])
 def create_user(pnr_hash):
     """Allow a pending user to set a password and activate the account."""

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Summary
- add robots.txt to disallow all crawlers
- expose robots.txt via Flask route

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4202673a4832dbd64999b01a98b4b