### PR TITLE
feat: show progress during admin user creation

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -235,3 +235,21 @@ footer {
 .create-account .license-note {
     margin-top: 16px;
 }
+
+/* --- Progress indicator for admin user creation --- */
+.progress-container {
+    margin-top: 14px;
+}
+
+.progress-bar {
+    height: 4px;
+    width: 0;
+    background: #007bff;
+    transition: width 0.5s linear;
+}
+
+.progress-text {
+    margin-top: 8px;
+    font-size: 0.9rem;
+    color: #555;
+}

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -5,6 +5,8 @@
   const form = document.getElementById('adminForm');
   const result = document.getElementById('result');
   const submitBtn = document.getElementById('submitBtn');
+  const progressContainer = document.getElementById('progressContainer');
+  const progressBar = document.getElementById('progressBar');
 
   // Fält
   const emailInput = document.getElementById('email');
@@ -31,6 +33,23 @@
     result.style.display = 'none';
     result.textContent = '';
     result.className = 'message';
+  }
+
+  // --- Progress bar handling ---
+  let progressInterval;
+  function startProgress() {
+    progressContainer.style.display = 'block';
+    let width = 0;
+    progressBar.style.width = '0%';
+    progressInterval = setInterval(() => {
+      width = (width + 10) % 100;
+      progressBar.style.width = `${width}%`;
+    }, 500);
+  }
+
+  function stopProgress() {
+    progressContainer.style.display = 'none';
+    clearInterval(progressInterval);
   }
 
   // --- Enkel validering ---
@@ -96,7 +115,8 @@
 
     // Skicka
     submitBtn.disabled = true;
-        submitBtn.textContent = 'Skapar...';
+    submitBtn.textContent = 'Skapar...';
+    startProgress();
 
     try {
       const res = await fetch('/admin', {
@@ -131,7 +151,8 @@
       // console.error(err);
     } finally {
       submitBtn.disabled = false;
-        submitBtn.textContent = 'Skapa användare';
+      submitBtn.textContent = 'Skapa användare';
+      stopProgress();
     }
   });
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -28,6 +28,11 @@
 
         <button id="submitBtn" type="submit">Skapa användare</button>
 
+        <div id="progressContainer" class="progress-container" style="display:none">
+            <div id="progressBar" class="progress-bar"></div>
+            <p class="progress-text">Skapar användare… Detta kan ta upp till 30 sekunder.</p>
+        </div>
+
         <div id="result" class="message" style="display:none"></div>
     </form>
 <script src="{{ url_for('static', filename='js/admin.js') }}"></script>


### PR DESCRIPTION
## Summary
- show progress bar with time estimate when creating users from admin page
- add styles and JavaScript to animate progress indicator

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b42765faf8832d993f9880cf994a24