### PR TITLE
Allow multiple PDF uploads up to 100MB

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -13,7 +13,7 @@
   const pdfInput = document.getElementById('pdf');
 
   // --- Konstanter (synka gärna med servern) ---
-  const MAX_MB = 16; // matchar app.config['MAX_CONTENT_LENGTH']
+  const MAX_MB = 100; // matchar app.config['MAX_CONTENT_LENGTH']
   const MAX_BYTES = MAX_MB * 1024 * 1024;
   const ALLOWED_MIME = 'application/pdf';
 
@@ -63,7 +63,7 @@
     const email = emailInput.value.trim();
     const username = usernameInput.value.trim();
     const pnr = pnrInput.value.trim();
-    const file = pdfInput.files[0];
+    const files = Array.from(pdfInput.files);
 
     if (!isValidEmail(email)) {
       showMessage('error', 'Ogiltig e-postadress.');
@@ -80,11 +80,24 @@
       pnrInput.focus();
       return;
     }
-    const pdfError = validatePdf(file);
-    if (pdfError) {
-      showMessage('error', pdfError);
+    if (!files.length) {
+      showMessage('error', 'PDF-fil saknas.');
       pdfInput.focus();
       return;
+    }
+    const totalSize = files.reduce((sum, f) => sum + f.size, 0);
+    if (totalSize > MAX_BYTES) {
+      showMessage('error', `Filerna är för stora (max ${MAX_MB} MB totalt).`);
+      pdfInput.focus();
+      return;
+    }
+    for (const file of files) {
+      const pdfError = validatePdf(file);
+      if (pdfError) {
+        showMessage('error', pdfError);
+        pdfInput.focus();
+        return;
+      }
     }
 
     // Bygg FormData (måste matcha serverns förväntningar: email, username, personnummer, pdf)
@@ -92,7 +105,9 @@
     fd.append('email', email);
     fd.append('username', username);
     fd.append('personnummer', pnr);
-    fd.append('pdf', file);
+    for (const file of files) {
+      fd.append('pdf', file);
+    }
 
     // Skicka
     submitBtn.disabled = true;

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -20,9 +20,9 @@
             </div>
 
             <div class="col">
-                <label for="pdf">Ladda upp PDF</label>
-                <input id="pdf" name="pdf" type="file" accept="application/pdf" required />
-                <small class="hint">Endast PDF-filer är tillåtna.</small>
+                <label for="pdf">Ladda upp PDF-filer</label>
+                <input id="pdf" name="pdf" type="file" accept="application/pdf" multiple required />
+                <small class="hint">Endast PDF-filer (max 100 MB totalt).</small>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Let admins upload several PDFs per user and raise upload limit to 100MB
- Handle storing multiple PDF paths in database and adjust client-side form and validation
- Expand tests to cover multiple PDF uploads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4295b4548832d835469c00a55b647