### PR TITLE
Add volume for TLS certificates

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -28,10 +28,15 @@ docker run -d -p 80:80 \
   -v uploads_data:/app/uploads \
   -v db_data:/data \
   -v logs_data:/app/logs \
+  -v certs_data:/certs \
   ghcr.io/mr-cool08/jk-utbildnings-intyg:latest
 ```
 
 The volumes are created automatically if they do not exist. On first start the container copies `.example.env` into the `env_data` volume as `.env`. Edit this file and restart the container to update environment variables.
+
+Store your Cloudflare certificate and key inside the `certs_data` volume and
+reference them in `.env` via `CLOUDFLARE_CERT_PATH=/certs/cert.pem` and
+`CLOUDFLARE_KEY_PATH=/certs/key.pem`.
 
 If you later change any values in the `.env` file, restart the container so the new configuration takes effect.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # Ensure runtime directories exist, seed configuration volume
-RUN mkdir -p /data /app/uploads /config \
+RUN mkdir -p /data /app/uploads /config /certs \
     && cp .example.env /config/.env
-VOLUME ["/data", "/app/uploads", "/config"]
+VOLUME ["/data", "/app/uploads", "/config", "/certs"]
 
 # Configure port and default database location
 ENV PORT=8080 \

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ This web application manages the issuance and storage of course certificates. It
    ```
    The app will be available on <http://localhost:80>. For container-based deployment see [DEPLOYMENT.md](DEPLOYMENT.md).
 
+### Optional: Cloudflare TLS support
+
+If you are using [Cloudflare Origin Certificates](https://developers.cloudflare.com/ssl/origin-configuration/origin-ca/),
+provide the certificate and key paths via the ``CLOUDFLARE_CERT_PATH`` and
+``CLOUDFLARE_KEY_PATH`` environment variables. When both are set the
+application will start with TLS enabled using those files. When running the
+Docker setup, store the certificate and key in the `/certs` volume and point
+the variables to those paths (e.g. `/certs/cert.pem` and `/certs/key.pem`).
+
 ## How it works for administrators
 
 * **Login** – Administrators sign in with credentials configured by the owner. A valid session grants access to the admin panel.
@@ -45,6 +54,7 @@ Running the application with Docker Compose stores mutable data in named volumes
 * `uploads_data` – keeps user uploads available at `/app/uploads`.
 * `db_data` – persists the SQLite database in `/data/database.db`.
 * `logs_data` – retains application logs under `/app/logs/`.
+* `certs_data` – holds TLS certificates mounted at `/certs`.
 
 Ensure the `env_data` volume includes a valid `.env` file before starting the container to provide required configuration values.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,13 +8,17 @@ services:
       - .env
     environment:
       DB_PATH: /data/database.db
+      # CLOUDFLARE_CERT_PATH: /certs/cert.pem
+      # CLOUDFLARE_KEY_PATH: /certs/key.pem
     volumes:
       - env_data:/config
       - uploads_data:/app/uploads
       - db_data:/data
       - logs_data:/app/logs
+      - certs_data:/certs
 volumes:
   env_data:
   uploads_data:
   db_data:
   logs_data:
+  certs_data:

--- a/tests/test_tls_support.py
+++ b/tests/test_tls_support.py
@@ -1,0 +1,15 @@
+import importlib
+import wsgi
+
+def test_get_ssl_context_none(monkeypatch):
+    monkeypatch.delenv("CLOUDFLARE_CERT_PATH", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_KEY_PATH", raising=False)
+    importlib.reload(wsgi)
+    assert wsgi.get_ssl_context() is None
+
+
+def test_get_ssl_context_with_paths(monkeypatch):
+    monkeypatch.setenv("CLOUDFLARE_CERT_PATH", "/tmp/cert.pem")
+    monkeypatch.setenv("CLOUDFLARE_KEY_PATH", "/tmp/key.pem")
+    importlib.reload(wsgi)
+    assert wsgi.get_ssl_context() == ("/tmp/cert.pem", "/tmp/key.pem")

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,12 +1,33 @@
 import os
 from app import app as application
+
+
+def get_ssl_context():
+    """Return an SSL context tuple if Cloudflare cert paths are set.
+
+    The application can run with a Cloudflare Origin Certificate by
+    specifying ``CLOUDFLARE_CERT_PATH`` and ``CLOUDFLARE_KEY_PATH``
+    environment variables. When both values are present the paths are
+    returned as a tuple suitable for ``Flask.run``'s ``ssl_context``
+    parameter. Otherwise ``None`` is returned so the app starts without
+    TLS.
+    """
+
+    cert_path = os.getenv("CLOUDFLARE_CERT_PATH")
+    key_path = os.getenv("CLOUDFLARE_KEY_PATH")
+    if cert_path and key_path:
+        return cert_path, key_path
+    return None
+
+
 debug = os.getenv("FLASK_DEBUG", "False").lower() in ("true", "1", "yes")
 
 
 if __name__ == "__main__":
     # This allows running the app with `python wsgi.py`
     application.run(
-    host="0.0.0.0",
-    port=int(os.getenv("PORT", 80)),
-    debug=debug
-)
+        host="0.0.0.0",
+        port=int(os.getenv("PORT", 80)),
+        debug=debug,
+        ssl_context=get_ssl_context(),
+    )


### PR DESCRIPTION
## Summary
- add `/certs` runtime directory and volume in Dockerfile
- mount `certs_data` volume in Docker Compose and document optional env vars
- update documentation for storing Cloudflare certificates in `/certs`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b42b0fda3c832d86bfc1aa609ec80f