### PR TITLE
Update example env with DB and TLS variables

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -17,6 +17,14 @@ secret_key=your_secret_key
 # Salt used for hashing personal data such as email and personnummer
 HASH_SALT=choose_a_good_salt
 
+# Path to the SQLite database file
+DB_PATH=/data/database.db
+
+# Optional: Cloudflare Origin Certificate for TLS
+# When both values are provided the application will start with HTTPS.
+CLOUDFLARE_CERT_PATH=/certs/cert.pem
+CLOUDFLARE_KEY_PATH=/certs/key.pem
+
 # Enable debug mode for development
 FLASK_DEBUG=False
 


### PR DESCRIPTION
## Summary
- Document database path in example env file
- Add optional Cloudflare TLS certificate paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b42f9d8f0c832db24d37dbf94e91f1