### PR TITLE
Mount Cloudflare certificates from user home directory

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -22,6 +22,8 @@ DB_PATH=/data/database.db
 
 # Optional: Cloudflare Origin Certificate for TLS
 # When both values are provided the application will start with HTTPS.
+# Store the files in `/home/client_52_3/certs` on the host and mount that
+# directory to `/certs` in the container.
 CLOUDFLARE_CERT_PATH=/certs/cert.pem
 CLOUDFLARE_KEY_PATH=/certs/key.pem
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -28,13 +28,15 @@ docker run -d -p 80:80 \
   -v uploads_data:/app/uploads \
   -v db_data:/data \
   -v logs_data:/app/logs \
-  -v certs_data:/certs \
+  -v /home/client_52_3/certs:/certs \
   ghcr.io/mr-cool08/jk-utbildnings-intyg:latest
 ```
 
-The volumes are created automatically if they do not exist. On first start the container copies `.example.env` into the `env_data` volume as `.env`. Edit this file and restart the container to update environment variables.
+The named volumes are created automatically if they do not exist. On first
+start the container copies `.example.env` into the `env_data` volume as `.env`.
+Edit this file and restart the container to update environment variables.
 
-Store your Cloudflare certificate and key inside the `certs_data` volume and
+Place your Cloudflare certificate and key in `/home/client_52_3/certs` and
 reference them in `.env` via `CLOUDFLARE_CERT_PATH=/certs/cert.pem` and
 `CLOUDFLARE_KEY_PATH=/certs/key.pem`.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY . .
 # Ensure runtime directories exist, seed configuration volume
 RUN mkdir -p /data /app/uploads /config /certs \
     && cp .example.env /config/.env
-VOLUME ["/data", "/app/uploads", "/config", "/certs"]
+VOLUME ["/data", "/app/uploads", "/config"]
 
 # Configure port and default database location
 ENV PORT=8080 \

--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ This web application manages the issuance and storage of course certificates. It
 If you are using [Cloudflare Origin Certificates](https://developers.cloudflare.com/ssl/origin-configuration/origin-ca/),
 provide the certificate and key paths via the ``CLOUDFLARE_CERT_PATH`` and
 ``CLOUDFLARE_KEY_PATH`` environment variables. When both are set the
-application will start with TLS enabled using those files. When running the
-Docker setup, store the certificate and key in the `/certs` volume and point
-the variables to those paths (e.g. `/certs/cert.pem` and `/certs/key.pem`).
+application will start with TLS enabled using those files. For the Docker
+setup, place the certificate and key in the `client_52_3` home directory (for
+example `/home/client_52_3/certs/`) and mount that directory to `/certs`
+inside the container. Point the variables to those paths (e.g.
+`/certs/cert.pem` and `/certs/key.pem`).
 
 ## How it works for administrators
 
@@ -54,7 +56,9 @@ Running the application with Docker Compose stores mutable data in named volumes
 * `uploads_data` – keeps user uploads available at `/app/uploads`.
 * `db_data` – persists the SQLite database in `/data/database.db`.
 * `logs_data` – retains application logs under `/app/logs/`.
-* `certs_data` – holds TLS certificates mounted at `/certs`.
+
+Cloudflare certificates are stored outside of Docker volumes in
+`/home/client_52_3/certs` and mounted to `/certs` in the container.
 
 Ensure the `env_data` volume includes a valid `.env` file before starting the container to provide required configuration values.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,9 @@ services:
       - uploads_data:/app/uploads
       - db_data:/data
       - logs_data:/app/logs
-      - certs_data:/certs
+      - /home/client_52_3/certs:/certs
 volumes:
   env_data:
   uploads_data:
   db_data:
   logs_data:
-  certs_data:


### PR DESCRIPTION
## Summary
- mount `/home/client_52_3/certs` into the container instead of using a Docker volume
- document new Cloudflare certificate location in README, deployment guide, and example env
- drop `/certs` from Dockerfile volumes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b430a491d0832d9d12b37df2c90572