### PR TITLE
Enable optional TLS via entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ COPY . .
 
 # Ensure runtime directories exist, seed configuration volume
 RUN mkdir -p /data /app/uploads /config /certs \
-    && cp .example.env /config/.env
+    && cp .example.env /config/.env \
+    && chmod +x entrypoint.sh
 VOLUME ["/data", "/app/uploads", "/config"]
 
 # Configure port and default database location
@@ -23,6 +24,6 @@ ENV PORT=8080 \
 
 EXPOSE 8080
 
-# Run the application with Gunicorn
-CMD ["sh", "-c", "gunicorn app:app --workers=3 --bind=0.0.0.0:$PORT --access-logfile=- --error-logfile=- --log-level=debug --capture-output"]
+# Run the application with optional Cloudflare certificates
+CMD ["./entrypoint.sh"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ -n "$CLOUDFLARE_CERT_PATH" ] && [ -n "$CLOUDFLARE_KEY_PATH" ]; then
+    exec gunicorn app:app --workers=3 --bind=0.0.0.0:$PORT --access-logfile=- --error-logfile=- --log-level=debug --capture-output --certfile="$CLOUDFLARE_CERT_PATH" --keyfile="$CLOUDFLARE_KEY_PATH"
+else
+    exec gunicorn app:app --workers=3 --bind=0.0.0.0:$PORT --access-logfile=- --error-logfile=- --log-level=debug --capture-output
+fi


### PR DESCRIPTION
## Summary
- add `entrypoint.sh` to launch Gunicorn with Cloudflare certs when paths are provided
- update Dockerfile to run the new entrypoint and mark it executable

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4331c5e6c832da78b39822b3dd91b