### PR TITLE
Use named volumes

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -32,7 +32,7 @@ docker run -d -p 80:80 \
   ghcr.io/mr-cool08/jk-utbildnings-intyg:latest
 ```
 
-The named volumes are created automatically if they do not exist. On first
+The named volumes are created automatically if they do not exist and reused if present. On first
 start the container copies `.example.env` into the `env_data` volume as `.env`.
 Edit this file and restart the container to update environment variables.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Running the application with Docker Compose stores mutable data in named volumes
 * `uploads_data` – keeps user uploads available at `/app/uploads`.
 * `db_data` – persists the SQLite database in `/data/database.db`.
 * `logs_data` – retains application logs under `/app/logs/`.
+These volumes have fixed names so existing data is reused across container rebuilds.
 
 Cloudflare certificates are stored outside of Docker volumes in
 `/home/client_52_3/certs` and mounted to `/certs` in the container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,10 @@ services:
       - /home/client_52_3/certs:/certs
 volumes:
   env_data:
+    name: env_data
   uploads_data:
+    name: uploads_data
   db_data:
+    name: db_data
   logs_data:
+    name: logs_data


### PR DESCRIPTION
## Summary
- give Docker volumes explicit names so existing data is reused
- document that named volumes are preserved across rebuilds

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b433657580832dabb8f4e0d72c00e6