### PR TITLE
Use user home path for TLS certificates

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -28,7 +28,7 @@ docker run -d -p 80:80 \
   -v uploads_data:/app/uploads \
   -v db_data:/data \
   -v logs_data:/app/logs \
-  -v /home/client_52_3/certs:/certs \
+  -v /home/client_52_3/certs:/home/client_52_3/certs \
   ghcr.io/mr-cool08/jk-utbildnings-intyg:latest
 ```
 
@@ -37,8 +37,8 @@ start the container copies `.example.env` into the `env_data` volume as `.env`.
 Edit this file and restart the container to update environment variables.
 
 Place your Cloudflare certificate and key in `/home/client_52_3/certs` and
-reference them in `.env` via `CLOUDFLARE_CERT_PATH=/certs/cert.pem` and
-`CLOUDFLARE_KEY_PATH=/certs/key.pem`.
+reference them in `.env` via `CLOUDFLARE_CERT_PATH=/home/client_52_3/certs/cert.pem`
+and `CLOUDFLARE_KEY_PATH=/home/client_52_3/certs/key.pem`.
 
 If you later change any values in the `.env` file, restart the container so the new configuration takes effect.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,17 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # Ensure runtime directories exist, seed configuration volume
-RUN mkdir -p /data /app/uploads /config /certs \
+RUN mkdir -p /data /app/uploads /config /home/client_52_3/certs \
     && cp .example.env /config/.env \
     && chmod +x entrypoint.sh
 VOLUME ["/data", "/app/uploads", "/config"]
 
-# Configure port and default database location
+# Configure port, database, and default certificate locations
 ENV PORT=8080 \
     DB_PATH=/data/database.db \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    CLOUDFLARE_CERT_PATH=/home/client_52_3/certs/cert.pem \
+    CLOUDFLARE_KEY_PATH=/home/client_52_3/certs/key.pem
 
 EXPOSE 8080
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ provide the certificate and key paths via the ``CLOUDFLARE_CERT_PATH`` and
 ``CLOUDFLARE_KEY_PATH`` environment variables. When both are set the
 application will start with TLS enabled using those files. For the Docker
 setup, place the certificate and key in the `client_52_3` home directory (for
-example `/home/client_52_3/certs/`) and mount that directory to `/certs`
-inside the container. Point the variables to those paths (e.g.
-`/certs/cert.pem` and `/certs/key.pem`).
+example `/home/client_52_3/certs/`) and mount that directory at the same path
+inside the container. Point the variables to those files (e.g.
+`/home/client_52_3/certs/cert.pem` and `/home/client_52_3/certs/key.pem`).
 
 ## How it works for administrators
 
@@ -59,7 +59,8 @@ Running the application with Docker Compose stores mutable data in named volumes
 These volumes have fixed names so existing data is reused across container rebuilds.
 
 Cloudflare certificates are stored outside of Docker volumes in
-`/home/client_52_3/certs` and mounted to `/certs` in the container.
+`/home/client_52_3/certs` and mounted to `/home/client_52_3/certs` in the
+container.
 
 Ensure the `env_data` volume includes a valid `.env` file before starting the container to provide required configuration values.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,14 +8,16 @@ services:
       - .env
     environment:
       DB_PATH: /data/database.db
-      # CLOUDFLARE_CERT_PATH: /certs/cert.pem
-      # CLOUDFLARE_KEY_PATH: /certs/key.pem
+      # Uncomment the lines below to enable TLS with certificates stored at
+      # /home/client_52_3/certs inside the container.
+      # CLOUDFLARE_CERT_PATH: /home/client_52_3/certs/cert.pem
+      # CLOUDFLARE_KEY_PATH: /home/client_52_3/certs/key.pem
     volumes:
       - env_data:/config
       - uploads_data:/app/uploads
       - db_data:/data
       - logs_data:/app/logs
-      - /home/client_52_3/certs:/certs
+      - /home/client_52_3/certs:/home/client_52_3/certs
 volumes:
   env_data:
     name: env_data


### PR DESCRIPTION
## Summary
- Point Docker image to `/home/client_52_3/certs` for Cloudflare certificates
- Document new certificate path in README and deployment guide
- Update Docker Compose volume mapping and comments for TLS variables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b434c46940832d9e71c0265d46ed97