### PR TITLE
Fix Docker base image for runtime stability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use official Python runtime as a parent image
-FROM python:3.14.0rc2-alpine3.22
+# Use a stable Python runtime as the base image
+FROM python:3.12-alpine
 
 # Set work directory
 WORKDIR /app
@@ -12,12 +12,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # Ensure runtime directories exist, seed configuration volume
-RUN mkdir -p /data /app/uploads /config /home/client_52_3/certs \
+RUN mkdir -p /data /app/uploads /config /certs \
     && cp .example.env /config/.env \
     && chmod +x entrypoint.sh
 VOLUME ["/data", "/app/uploads", "/config"]
 
-# Configure port, database, and default certificate locations
 # Configure port, database, and default certificate locations
 ENV PORT=8080 \
     DB_PATH=/data/database.db \


### PR DESCRIPTION
## Summary
- use stable Python 3.12 alpine base image
- ensure certificate directory exists at /certs during build

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b74497acf4832dae84ca4159d7bb24