### PR TITLE
feat: enable default TLS configuration

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,15 @@ set -e
 # Default workers om inget annat anges
 WORKERS=${WORKERS:-3}
 
-if [ -f "$CLOUDFLARE_CERT_PATH" ] && [ -f "$CLOUDFLARE_KEY_PATH" ]; then
-    echo "Starting Gunicorn with TLS using $CLOUDFLARE_CERT_PATH and $CLOUDFLARE_KEY_PATH"
+# Look for TLS assets in the ubuntu user's home directory by default. This
+# matches the location provided in the deployment environment where
+# ``cert.pem`` and ``key.pem`` are copied directly under
+# ``/home/client_52_3``.
+CERT_PATH=${CLOUDFLARE_CERT_PATH:-/home/client_52_3/cert.pem}
+KEY_PATH=${CLOUDFLARE_KEY_PATH:-/home/client_52_3/key.pem}
+
+if [ -f "$CERT_PATH" ] && [ -f "$KEY_PATH" ]; then
+    echo "Starting Gunicorn with TLS using $CERT_PATH and $KEY_PATH"
     exec gunicorn app:app \
         --workers="$WORKERS" \
         --bind=0.0.0.0:$PORT \
@@ -13,8 +20,8 @@ if [ -f "$CLOUDFLARE_CERT_PATH" ] && [ -f "$CLOUDFLARE_KEY_PATH" ]; then
         --error-logfile=- \
         --log-level=debug \
         --capture-output \
-        --certfile="$CLOUDFLARE_CERT_PATH" \
-        --keyfile="$CLOUDFLARE_KEY_PATH"
+        --certfile="$CERT_PATH" \
+        --keyfile="$KEY_PATH"
 else
     echo "TLS certs not found, starting Gunicorn without TLS"
     exec gunicorn app:app \

--- a/tests/test_tls_support.py
+++ b/tests/test_tls_support.py
@@ -1,15 +1,42 @@
 import importlib
 import wsgi
 
-def test_get_ssl_context_none(monkeypatch):
+
+def test_get_ssl_context_none(monkeypatch, tmp_path):
     monkeypatch.delenv("CLOUDFLARE_CERT_PATH", raising=False)
     monkeypatch.delenv("CLOUDFLARE_KEY_PATH", raising=False)
     importlib.reload(wsgi)
+    monkeypatch.setattr(wsgi, "DEFAULT_CERT_PATH", str(tmp_path / "missing_cert.pem"))
+    monkeypatch.setattr(wsgi, "DEFAULT_KEY_PATH", str(tmp_path / "missing_key.pem"))
     assert wsgi.get_ssl_context() is None
 
 
-def test_get_ssl_context_with_paths(monkeypatch):
-    monkeypatch.setenv("CLOUDFLARE_CERT_PATH", "/tmp/cert.pem")
-    monkeypatch.setenv("CLOUDFLARE_KEY_PATH", "/tmp/key.pem")
+def test_get_ssl_context_with_paths(monkeypatch, tmp_path):
+    cert = tmp_path / "cert.pem"
+    key = tmp_path / "key.pem"
+    cert.write_text("cert")
+    key.write_text("key")
+    monkeypatch.setenv("CLOUDFLARE_CERT_PATH", str(cert))
+    monkeypatch.setenv("CLOUDFLARE_KEY_PATH", str(key))
     importlib.reload(wsgi)
-    assert wsgi.get_ssl_context() == ("/tmp/cert.pem", "/tmp/key.pem")
+    assert wsgi.get_ssl_context() == (str(cert), str(key))
+
+
+def test_get_ssl_context_default_paths(monkeypatch, tmp_path):
+    cert = tmp_path / "cert.pem"
+    key = tmp_path / "key.pem"
+    cert.write_text("cert")
+    key.write_text("key")
+    monkeypatch.delenv("CLOUDFLARE_CERT_PATH", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_KEY_PATH", raising=False)
+    importlib.reload(wsgi)
+    monkeypatch.setattr(wsgi, "DEFAULT_CERT_PATH", str(cert))
+    monkeypatch.setattr(wsgi, "DEFAULT_KEY_PATH", str(key))
+    assert wsgi.get_ssl_context() == (str(cert), str(key))
+
+
+def test_default_paths_constants():
+    importlib.reload(wsgi)
+    assert wsgi.DEFAULT_CERT_PATH == "/home/client_52_3/cert.pem"
+    assert wsgi.DEFAULT_KEY_PATH == "/home/client_52_3/key.pem"
+

--- a/wsgi.py
+++ b/wsgi.py
@@ -2,6 +2,14 @@ import os
 from app import app as application
 
 
+# Default locations for TLS certificate and key files. The files are placed
+# directly in the ubuntu user's home directory rather than a nested
+# "certs" folder so the application can pick them up automatically when no
+# explicit environment variables are provided.
+DEFAULT_CERT_PATH = "/home/client_52_3/cert.pem"
+DEFAULT_KEY_PATH = "/home/client_52_3/key.pem"
+
+
 def get_ssl_context():
     """Return an SSL context tuple if Cloudflare cert paths are set.
 
@@ -13,9 +21,9 @@ def get_ssl_context():
     TLS.
     """
 
-    cert_path = os.getenv("CLOUDFLARE_CERT_PATH")
-    key_path = os.getenv("CLOUDFLARE_KEY_PATH")
-    if cert_path and key_path:
+    cert_path = os.getenv("CLOUDFLARE_CERT_PATH", DEFAULT_CERT_PATH)
+    key_path = os.getenv("CLOUDFLARE_KEY_PATH", DEFAULT_KEY_PATH)
+    if os.path.isfile(cert_path) and os.path.isfile(key_path):
         return cert_path, key_path
     return None
 


### PR DESCRIPTION
## Summary
- default to `/home/client_52_3/cert.pem` and `/home/client_52_3/key.pem` for TLS certs
- fallback to plain HTTP when certificates are missing
- add tests covering env vars and default path behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7464b402c832d897dd4197c0da616