### PR TITLE
Fix newline handling in nginx TLS config

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,8 @@ elif [ ! -f "$CERT_PATH" ] || [ ! -f "$KEY_PATH" ]; then
 fi
 
 SSL_LISTEN="listen ${PORT} ssl;"
-TLS_CONFIG="ssl_certificate ${CERT_PATH};\n        ssl_certificate_key ${KEY_PATH};"
+TLS_CONFIG="ssl_certificate ${CERT_PATH};
+        ssl_certificate_key ${KEY_PATH};"
 
 # Generate nginx configuration
 cat > /etc/nginx/nginx.conf <<EOF


### PR DESCRIPTION
## Summary
- ensure TLS config lines in generated nginx.conf use actual newlines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b85e055454832daac005e560783963