### PR TITLE
Expose HTTP and HTTPS ports

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -14,7 +14,7 @@ You can build and run the container locally with Docker Compose:
 docker compose up --build
 ```
 
-The app will be available on <https://localhost>.
+The app will be available on <https://localhost> and <http://localhost>.
 
 ## Production deployment
 
@@ -23,7 +23,7 @@ Images are built and pushed to GHCR and Docker Hub on every push to the `main` b
 ```bash
 docker pull ghcr.io/mr-cool08/jk-utbildnings-intyg:latest
 
-docker run -d -p 443:8080 \
+docker run -d -p 80:80 -p 443:443 \
   -v env_data:/config \
   -v uploads_data:/app/uploads \
   -v db_data:/data \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,13 @@ RUN mkdir -p /data /app/uploads /config /run/nginx /etc/nginx/certs \
     && chmod +x entrypoint.sh
 VOLUME ["/data", "/app/uploads", "/config"]
 
-# Configure port and database
-ENV PORT=8080 \
+# Configure ports and database
+ENV HTTPS_PORT=443 \
+    HTTP_PORT=80 \
     DB_PATH=/data/database.db \
     PYTHONUNBUFFERED=1
 
-EXPOSE 8080
+EXPOSE 80 443
 
 # Run the application with optional TLS certificates
 CMD ["./entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   app:
     build: .
     ports:
-      # App lyssnar på 8080 i containern -> mappa värdens port 443 till 8080
-      - "443:8080"
+      - "80:80"
+      - "443:443"
     env_file:
       - .env
     environment:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,8 @@
 set -e
 
 # Default ports
-PORT=${PORT:-8080}
+HTTPS_PORT=${HTTPS_PORT:-443}
+HTTP_PORT=${HTTP_PORT:-80}
 FLASK_PORT=${FLASK_PORT:-5000}
 
 # Default certificate paths
@@ -24,7 +25,8 @@ elif [ ! -f "$CERT_PATH" ] || [ ! -f "$KEY_PATH" ]; then
         -newkey rsa:2048 -keyout "$KEY_PATH" -out "$CERT_PATH"
 fi
 
-SSL_LISTEN="listen ${PORT} ssl;"
+HTTP_LISTEN="listen ${HTTP_PORT};"
+SSL_LISTEN="listen ${HTTPS_PORT} ssl;"
 TLS_CONFIG="ssl_certificate ${CERT_PATH};
         ssl_certificate_key ${KEY_PATH};"
 
@@ -40,6 +42,7 @@ http {
     keepalive_timeout  65;
 
     server {
+        ${HTTP_LISTEN}
         ${SSL_LISTEN}
         server_name  _;
 

--- a/tests/test_docker_files.py
+++ b/tests/test_docker_files.py
@@ -11,13 +11,14 @@ def test_dockerfile_uses_python_base_image():
 
 def test_dockerfile_exposes_port_and_runs_entrypoint():
     dockerfile = (ROOT / "Dockerfile").read_text()
-    assert "EXPOSE 8080" in dockerfile
+    assert "EXPOSE 80 443" in dockerfile
     assert 'CMD ["./entrypoint.sh"]' in dockerfile
 
 
 def test_compose_maps_port_and_sets_db_path():
     compose = (ROOT / "docker-compose.yml").read_text()
-    assert re.search(r"-\s*\"443:8080\"", compose)
+    assert re.search(r"-\s*\"80:80\"", compose)
+    assert re.search(r"-\s*\"443:443\"", compose)
     assert "DB_PATH: /data/database.db" in compose
 
 


### PR DESCRIPTION
## Summary
- Serve the application over both HTTP and HTTPS
- Expose and document ports 80 and 443
- Adjust tests for new port configuration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b85fe998d0832daee625242d0bc426