### PR TITLE
Support SMTP over SSL for creation emails

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -2,10 +2,12 @@
 # Copy this file to `.env` and adjust the values for your environment.
 
 # SMTP server settings used to send account activation emails
+# Use port 587 for STARTTLS or 465 for SSL
 smtp_port=587
 smtp_server=smtp.example.com
 smtp_user=your_email@example.com
 smtp_password=your_password
+smtp_timeout=10
 
 # Administrator credentials for the admin panel
 admin_username=your_admin_username

--- a/tests/test_email_env.py
+++ b/tests/test_email_env.py
@@ -5,7 +5,7 @@ def test_send_creation_email_uses_env_credentials(monkeypatch):
 
     # Läs in exempel-credentials
     env_values = dotenv_values(".example.env")
-    for key in ("smtp_server", "smtp_port", "smtp_user", "smtp_password"):
+    for key in ("smtp_server", "smtp_port", "smtp_user", "smtp_password", "smtp_timeout"):
         monkeypatch.setenv(key, env_values[key])
 
     sent = {}
@@ -51,6 +51,7 @@ def test_send_creation_email_uses_env_credentials(monkeypatch):
     # Rätt server/port
     assert sent["server"] == env_values["smtp_server"]
     assert sent["port"] == int(env_values["smtp_port"])
+    assert sent["timeout"] == int(env_values["smtp_timeout"])
     # STARTTLS-sekvensen kördes
     assert sent["starttls_called"] is True
     assert sent["ehlo_calls"] >= 2  # EHLO före och efter STARTTLS
@@ -62,4 +63,60 @@ def test_send_creation_email_uses_env_credentials(monkeypatch):
     assert msg["To"] == "liamsuorsa08@gmail.com"
     assert msg["Subject"] == "Skapa ditt konto"
     # Innehållet ska innehålla länken
+    assert link in msg.get_content()
+
+
+def test_send_creation_email_uses_ssl_on_port_465(monkeypatch):
+    """Om port 465 anges ska funktionen använda SMTP_SSL utan STARTTLS."""
+    from dotenv import dotenv_values
+    import app
+
+    env_values = dotenv_values(".example.env")
+    for key in ("smtp_server", "smtp_user", "smtp_password", "smtp_timeout"):
+        monkeypatch.setenv(key, env_values[key])
+    monkeypatch.setenv("smtp_port", "465")
+
+    sent = {}
+
+    class DummySMTPSSL:
+        def __init__(self, server, port, context=None, timeout=30):
+            sent["server"] = server
+            sent["port"] = port
+            sent["timeout"] = timeout
+            sent["context_provided"] = context is not None
+
+        def ehlo(self):
+            sent["ehlo_called"] = True
+
+        def login(self, user, password):
+            sent["login"] = (user, password)
+
+        def send_message(self, msg):
+            sent["message"] = msg
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    class FailSMTP:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("SMTP should not be used for port 465")
+
+    monkeypatch.setattr(app, "SMTP_SSL", DummySMTPSSL)
+    monkeypatch.setattr(app, "SMTP", FailSMTP)
+
+    link = "https://example.com/create"
+    app.send_creation_email("liamsuorsa08@gmail.com", link)
+
+    assert sent["login"] == (env_values["smtp_user"], env_values["smtp_password"])
+    assert sent["server"] == env_values["smtp_server"]
+    assert sent["port"] == 465
+    assert sent["timeout"] == int(env_values["smtp_timeout"])
+    assert sent["context_provided"] is True
+    msg = sent["message"]
+    assert msg["From"] == env_values["smtp_user"]
+    assert msg["To"] == "liamsuorsa08@gmail.com"
+    assert msg["Subject"] == "Skapa ditt konto"
     assert link in msg.get_content()


### PR DESCRIPTION
## Summary
- allow `send_creation_email` to connect with `SMTP_SSL` when `smtp_port` is 465
- document port choice for STARTTLS vs SSL in `.example.env`
- test SSL path when port 465 is used

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b86972ad5c832db3faae972860b575