### PR TITLE
Expose app object for gunicorn

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -2,6 +2,9 @@ import os
 from pathlib import Path
 from app import app as application
 
+# Expose ``app`` for servers expecting this name (e.g., gunicorn's ``wsgi:app``)
+app = application
+
 
 # Default locations for TLS certificate and key files used by the Flask
 # development server. They mirror the paths consumed by the nginx


### PR DESCRIPTION
## Summary
- expose `app` alias in `wsgi` so gunicorn can load the application

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9b093876c832da42b01727edebe3b