### PR TITLE
Add health check endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -84,6 +84,12 @@ def create_app() -> Flask:
 app = create_app()
 
 
+@app.route("/health")
+def health() -> tuple[dict, int]:
+    """Basic health check endpoint."""
+    return {"status": "ok"}, 200
+
+
 import os, ssl, logging
 from smtplib import SMTP, SMTPException, SMTPAuthenticationError, SMTPServerDisconnected
 from email.message import EmailMessage

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,9 @@
+import app
+
+
+def test_health_endpoint_returns_ok():
+    with app.app.test_client() as client:
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.get_json() == {"status": "ok"}
+


### PR DESCRIPTION
## Summary
- add `/health` endpoint returning status OK
- test health check endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9b3cf80a4832dab17a26a18b60436