### PR TITLE
Handle PDF uploads for existing users by email

### DIFF
--- a/app.py
+++ b/app.py
@@ -357,11 +357,14 @@ def admin():
                     logger.warning("Admin upload without PDF")
                     return jsonify({'status': 'error', 'message': 'PDF-fil saknas'}), 400
 
+                # Kontrollera om användaren redan finns (via personnummer eller e-post)
+                user_exists = functions.get_user_info(personnummer) or functions.check_user_exists(email)
+
                 # spara filerna i mapp per personnummer
                 pdf_paths = [save_pdf_for_user(personnummer, f) for f in pdf_files]
 
                 # Om användaren redan finns ska endast PDF:erna sparas
-                if functions.get_user_info(personnummer):
+                if user_exists:
                     logger.info("PDFs uploaded for existing user %s", personnummer)
                     return jsonify(
                         {

--- a/tests/test_admin_upload.py
+++ b/tests/test_admin_upload.py
@@ -35,3 +35,41 @@ def test_admin_upload_existing_user_only_saves_pdf(empty_db, tmp_path, monkeypat
         response = client.post("/admin", data=data, content_type="multipart/form-data")
         assert response.status_code == 200
         assert response.get_json()["status"] == "success"
+
+
+def test_admin_upload_existing_email(tmp_path, empty_db, monkeypatch):
+    monkeypatch.setitem(app.app.config, "UPLOAD_ROOT", tmp_path)
+
+    conn = sqlite3.connect(empty_db)
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO users (username, email, password, personnummer) VALUES (?, ?, ?, ?)",
+        (
+            "Existing",
+            functions.hash_value("exist@example.com"),
+            functions.hash_password("secret"),
+            functions.hash_value("199001011234"),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    pdf_bytes = b"%PDF-1.4 test"
+    data = {
+        "email": "exist@example.com",
+        "username": "Existing",
+        "personnummer": "20000101-9999",
+        "pdf": (io.BytesIO(pdf_bytes), "doc.pdf"),
+    }
+
+    with app.app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["admin_logged_in"] = True
+        response = client.post("/admin", data=data, content_type="multipart/form-data")
+        assert response.status_code == 200
+        assert response.get_json()["status"] == "success"
+
+    pnr_hash = functions.hash_value(functions.normalize_personnummer("20000101-9999"))
+    saved_dir = tmp_path / pnr_hash
+    assert saved_dir.exists()
+    assert any(p.suffix == ".pdf" for p in saved_dir.iterdir())


### PR DESCRIPTION
## Summary
- Allow admin uploads to detect existing users via email or personnummer and skip duplicate creation while saving PDFs
- Test that uploading a certificate for an already-registered email succeeds and stores the file

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c41c63f46c832d9be92064c062d9c8