### PR TITLE
Add admin password reset workflow and forgot password handling

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -8,6 +8,7 @@ smtp_server=smtp.example.com
 smtp_user=your_email@example.com
 smtp_password=your_password
 smtp_timeout=10
+support_email=support@utbildningsintyg.se
 
 # Administrator credentials for the admin panel
 admin_username=your_admin_username

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -90,6 +90,17 @@ button {
     cursor: pointer;
 }
 
+.form-actions {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin-top: 14px;
+}
+
+.form-actions button {
+    margin-top: 0;
+}
+
 button[disabled] {
     opacity: 0.6;
     cursor: default;

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -4,6 +4,8 @@
     <h1>Admin — Skapa användare</h1>
     <p>Använd detta formulär för att lägga till en väntande användare. Fälten är obligatoriska. När POST lyckas lägger servern in posten i <code>pending_users</code>.</p>
 
+    <a class="btn" href="{{ url_for('admin_reset_user') }}">Återställ användarlösenord</a>
+
     <form id="adminForm" autocomplete="off" enctype="multipart/form-data" method="post">
         <label for="email">E-post</label>
         <input id="email" name="email" type="email" required placeholder="user@example.com" />

--- a/templates/admin_reset_user.html
+++ b/templates/admin_reset_user.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block title %}Admin — Återställ lösenord{% endblock %}
+{% block content %}
+    <h1>Återställ användarlösenord</h1>
+    <p>Flytta en befintlig användare tillbaka till väntande läge för att skicka en ny länk för att skapa lösenord.</p>
+    {% if error %}<p class="error">{{ error }}</p>{% endif %}
+    {% if message %}
+        <p class="success">{{ message }}</p>
+        {% if username %}<p class="message">Kontrollera att {{ username }} mottagit e-postmeddelandet.</p>{% endif %}
+    {% endif %}
+    <form method="post" autocomplete="off">
+        <label for="email">E-post</label>
+        <input id="email" name="email" type="email" required placeholder="user@example.com" />
+
+        <label for="personnummer">Personnummer</label>
+        <input id="personnummer" name="personnummer" type="text" required pattern="[\d\-]{6,14}" placeholder="ÅÅMMDDNNNN" />
+        <small class="hint">Ange samma e-postadress som är registrerad för användaren.</small>
+
+        <button type="submit">Flytta till väntande användare</button>
+    </form>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,6 +17,7 @@
                 <a href="/logout">Logga ut</a>
             {% elif session.get('admin_logged_in') %}
                 <a href="/admin">Admin</a>
+                <a href="/admin/reset-user">Återställ lösenord</a>
                 <a href="/logout">Logga ut</a>
             {% else %}
                 <a href="/login">Användarinloggning</a>

--- a/templates/user_login.html
+++ b/templates/user_login.html
@@ -3,11 +3,15 @@
 {% block content %}
     <h1>Användarinloggning</h1>
     {% if error %}<p class="error">{{ error }}</p>{% endif %}
+    {% if message %}<p class="success">{{ message }}</p>{% endif %}
     <form action="/login" method="POST">
         <label for="personnummer">Personnummer:</label>
         <input type="text" id="personnummer" name="personnummer" required>
         <label for="password">Lösenord:</label>
         <input type="password" id="password" name="password" required>
-        <button type="submit">Logga in</button>
+        <div class="form-actions">
+            <button type="submit" name="action" value="login">Logga in</button>
+            <button type="submit" name="action" value="forgot-password" formnovalidate>Glömt lösenord</button>
+        </div>
     </form>
 {% endblock %}

--- a/tests/test_admin_reset_user.py
+++ b/tests/test_admin_reset_user.py
@@ -1,0 +1,63 @@
+import app
+import functions
+
+
+def test_admin_reset_requires_login(empty_db):
+    with app.app.test_client() as client:
+        response = client.get("/admin/reset-user")
+    assert response.status_code == 302
+    assert "/login_admin" in response.headers["Location"]
+
+
+def test_admin_reset_user_success(empty_db, monkeypatch):
+    reset_called = {}
+
+    def fake_reset(email, personnummer, upload_root):
+        reset_called["args"] = (email, personnummer, upload_root)
+        return {
+            "username": "User",
+            "personnummer_hash": "hashedpnr",
+            "pdf_paths": [],
+        }
+
+    send_called = {}
+
+    def fake_send(email, link):
+        send_called["args"] = (email, link)
+
+    monkeypatch.setattr(functions, "reset_user_to_pending", fake_reset)
+    monkeypatch.setattr(app, "send_creation_email", fake_send)
+
+    with app.app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["admin_logged_in"] = True
+        response = client.post(
+            "/admin/reset-user",
+            data={"email": "user@example.com", "personnummer": "19900101-1234"},
+        )
+
+    assert response.status_code == 200
+    assert "En återställningslänk har skickats" in response.get_data(as_text=True)
+    assert reset_called["args"][0] == "user@example.com"
+    assert reset_called["args"][1] == "19900101-1234"
+    assert reset_called["args"][2] == app.app.config["UPLOAD_ROOT"]
+    assert send_called["args"][0] == "user@example.com"
+    assert "create_user/hashedpnr" in send_called["args"][1]
+
+
+def test_admin_reset_user_value_error(empty_db, monkeypatch):
+    def fake_reset(*_):
+        raise ValueError("Användaren hittades inte.")
+
+    monkeypatch.setattr(functions, "reset_user_to_pending", fake_reset)
+
+    with app.app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["admin_logged_in"] = True
+        response = client.post(
+            "/admin/reset-user",
+            data={"email": "user@example.com", "personnummer": "19900101-1234"},
+        )
+
+    assert response.status_code == 200
+    assert "Användaren hittades inte" in response.get_data(as_text=True)

--- a/tests/test_forgot_password.py
+++ b/tests/test_forgot_password.py
@@ -1,0 +1,36 @@
+import app
+
+
+def test_forgot_password_notifies_support(empty_db, monkeypatch):
+    called = {}
+
+    def fake_send_support_email(pnr):
+        called["pnr"] = pnr
+
+    monkeypatch.setattr(app, "send_support_email", fake_send_support_email)
+
+    with app.app.test_client() as client:
+        response = client.post(
+            "/login",
+            data={"personnummer": "19900101-1234", "action": "forgot-password"},
+        )
+
+    assert response.status_code == 200
+    assert b"Supporten har informerats" in response.data
+    assert called["pnr"] == "19900101-1234"
+
+
+def test_forgot_password_invalid_personnummer(empty_db, monkeypatch):
+    def fake_send_support_email(_):
+        raise ValueError("Ogiltigt personnummerformat.")
+
+    monkeypatch.setattr(app, "send_support_email", fake_send_support_email)
+
+    with app.app.test_client() as client:
+        response = client.post(
+            "/login",
+            data={"personnummer": "invalid", "action": "forgot-password"},
+        )
+
+    assert response.status_code == 200
+    assert b"Ogiltigt personnummerformat" in response.data

--- a/tests/test_reset_user_to_pending.py
+++ b/tests/test_reset_user_to_pending.py
@@ -1,0 +1,97 @@
+import os
+import sqlite3
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import functions  # noqa: E402
+
+
+@pytest.fixture
+def configured_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    real_connect = sqlite3.connect
+
+    def connect_stub(_):
+        return real_connect(db_path)
+
+    monkeypatch.setattr(functions, "DB_PATH", str(db_path))
+    monkeypatch.setattr(functions.sqlite3, "connect", connect_stub)
+    monkeypatch.setattr(functions, "APP_ROOT", str(tmp_path))
+    functions.create_database()
+    return db_path
+
+
+def _insert_user(db_path, email, username, personnummer):
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO users (username, email, password, personnummer) VALUES (?, ?, ?, ?)",
+        (
+            username,
+            functions.hash_value(email),
+            functions.hash_password("secret"),
+            functions.hash_value(functions.normalize_personnummer(personnummer)),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_reset_user_to_pending_moves_user(configured_db, tmp_path):
+    email = "user@example.com"
+    username = "User"
+    personnummer = "19900101-1234"
+    _insert_user(configured_db, email, username, personnummer)
+
+    pnr_hash = functions.hash_value(functions.normalize_personnummer(personnummer))
+    uploads_root = tmp_path / "uploads" / pnr_hash
+    uploads_root.mkdir(parents=True)
+    pdf_path = uploads_root / "certificate.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4 test")
+
+    result = functions.reset_user_to_pending(email, personnummer, os.path.join(tmp_path, "uploads"))
+
+    assert result["username"] == username
+    assert result["personnummer_hash"] == pnr_hash
+    assert result["pdf_paths"] == [f"uploads/{pnr_hash}/certificate.pdf"]
+
+    conn = sqlite3.connect(configured_db)
+    cursor = conn.cursor()
+    cursor.execute("SELECT 1 FROM users WHERE personnummer = ?", (pnr_hash,))
+    assert cursor.fetchone() is None
+    cursor.execute(
+        "SELECT email, username, pdf_path FROM pending_users WHERE personnummer = ?",
+        (pnr_hash,),
+    )
+    pending_row = cursor.fetchone()
+    conn.close()
+
+    assert pending_row == (
+        functions.hash_value(email),
+        username,
+        f"uploads/{pnr_hash}/certificate.pdf",
+    )
+
+
+def test_reset_user_to_pending_email_mismatch(configured_db, tmp_path):
+    email = "user@example.com"
+    username = "User"
+    personnummer = "19900101-1234"
+    _insert_user(configured_db, email, username, personnummer)
+
+    with pytest.raises(ValueError):
+        functions.reset_user_to_pending(
+            "wrong@example.com",
+            personnummer,
+            os.path.join(tmp_path, "uploads"),
+        )
+
+
+def test_reset_user_to_pending_missing_user(configured_db, tmp_path):
+    with pytest.raises(ValueError):
+        functions.reset_user_to_pending(
+            "missing@example.com",
+            "19900101-1234",
+            os.path.join(tmp_path, "uploads"),
+        )


### PR DESCRIPTION
## Summary
- add a reusable SMTP helper and support notification so users can trigger a forgot-password email to support from the login view
- add an admin password reset page that moves accounts back to the pending table, resends creation links, and update templates/CSS to surface the new flow
- extend the database helpers for resetting users and cover the new behaviours with focused tests and configuration docs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8508b6380832d847ff608aa59278c