### PR TITLE
Migrate storage to PostgreSQL and persist PDFs in database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,15 @@
 version: '3.9'
 services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: appuser
+      POSTGRES_PASSWORD: apppassword
+      POSTGRES_DB: appdb
   app:
     build: .
+    depends_on:
+      - db
     ports:
       - "80:80"
       - "443:443"
@@ -9,19 +17,4 @@ services:
     env_file:
       - .env
     environment:
-      DB_PATH: /data/database.db
-    volumes:
-      - env_data:/config
-      - uploads_data:/app/uploads
-      - db_data:/data
-      - logs_data:/app/logs
-
-volumes:
-  env_data:
-    name: env_data
-  uploads_data:
-    name: uploads_data
-  db_data:
-    name: db_data
-  logs_data:
-    name: logs_data
+      DATABASE_URL: postgresql+psycopg://appuser:apppassword@db:5432/appdb

--- a/functions.py
+++ b/functions.py
@@ -1,38 +1,129 @@
 """Database helpers and utility functions for the Flask application."""
 
-import logging
-import sqlite3
+from __future__ import annotations
+
 import hashlib
+import logging
 import os
 import re
 from datetime import datetime
 from functools import lru_cache
-from werkzeug.security import generate_password_hash, check_password_hash
+from typing import Any, Dict, List, Optional, Tuple
+
 from dotenv import load_dotenv
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Integer,
+    LargeBinary,
+    MetaData,
+    String,
+    Table,
+    create_engine,
+    delete,
+    func,
+    insert,
+    select,
+)
+from sqlalchemy.engine import Engine
+from sqlalchemy.engine.url import make_url
+from sqlalchemy.pool import StaticPool
+from werkzeug.security import check_password_hash, generate_password_hash
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)   # eller INFO i produktion
+logger.setLevel(logging.DEBUG)  # or INFO in production
 logger.propagate = True
-# Ensure environment variables from a .env file are loaded before accessing
-# configuration such as ``HASH_SALT``. Without this, a missing ``HASH_SALT``
-# would silently fall back to the insecure default below.
+
 load_dotenv(os.getenv("CONFIG_PATH", "/config/.env"))
 
-# Base directory to store the SQLite database so data persists across restarts.
 APP_ROOT = os.path.abspath(os.path.dirname(__file__))
 logger.debug("Application root directory: %s", APP_ROOT)
-# Allow overriding the database location via the ``DB_PATH`` environment variable
-# so it can be mounted on a host volume for persistence when running in Docker.
-DB_PATH = os.getenv("DB_PATH", os.path.join(APP_ROOT, "database.db"))
-logger.debug("Using database path: %s", DB_PATH)
 
-# Global salt used for deterministic hashing of personal data like email and
-# personnummer. Must remain constant or stored data cannot be retrieved.
 SALT = os.getenv("HASH_SALT", "static_salt")
 if SALT == "static_salt":
     logger.warning(
         "Using default HASH_SALT; set HASH_SALT in environment for stronger security"
     )
+
+metadata = MetaData()
+
+pending_users_table = Table(
+    "pending_users",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("username", String, nullable=False),
+    Column("email", String, nullable=False),
+    Column("personnummer", String, nullable=False, unique=True),
+)
+
+users_table = Table(
+    "users",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("username", String, nullable=False),
+    Column("email", String, nullable=False, unique=True),
+    Column("password", String, nullable=False),
+    Column("personnummer", String, nullable=False, unique=True),
+)
+
+user_pdfs_table = Table(
+    "user_pdfs",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("personnummer", String, nullable=False, index=True),
+    Column("filename", String, nullable=False),
+    Column("content", LargeBinary, nullable=False),
+    Column(
+        "uploaded_at",
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    ),
+)
+
+_ENGINE: Optional[Engine] = None
+
+
+def _build_engine() -> Engine:
+    """Create a SQLAlchemy engine based on configuration."""
+    db_url = os.getenv("DATABASE_URL")
+    if not db_url:
+        db_path = os.getenv("DB_PATH", os.path.join(APP_ROOT, "database.db"))
+        db_url = f"sqlite:///{db_path}"
+    url = make_url(db_url)
+    logger.debug("Creating engine for %s", db_url)
+    engine_kwargs: Dict[str, Any] = {"future": True}
+
+    if url.get_backend_name() == "sqlite":
+        database = url.database or ""
+        if database not in ("", ":memory:"):
+            os.makedirs(os.path.dirname(database), exist_ok=True)
+        connect_args = engine_kwargs.setdefault("connect_args", {})
+        connect_args["check_same_thread"] = False
+        if database in ("", ":memory:"):
+            engine_kwargs["poolclass"] = StaticPool
+    return create_engine(db_url, **engine_kwargs)
+
+
+def reset_engine() -> None:
+    """Reset the cached SQLAlchemy engine."""
+    global _ENGINE
+    _ENGINE = None
+
+
+def get_engine() -> Engine:
+    """Return a cached SQLAlchemy engine instance."""
+    global _ENGINE
+    if _ENGINE is None:
+        _ENGINE = _build_engine()
+    return _ENGINE
+
+
+def create_database() -> None:
+    """Create required tables if they do not exist."""
+    engine = get_engine()
+    metadata.create_all(engine)
+    logger.info("Database initialized")
 
 
 def hash_value(value: str) -> str:
@@ -54,14 +145,10 @@ def verify_password(hashed: str, password: str) -> bool:
 
 
 def normalize_personnummer(pnr: str) -> str:
-    """Normalize Swedish personal numbers to 12 digits.
-
-    Accepts inputs with or without separators (e.g., YYMMDD-XXXX, YYYYMMDDXXXX).
-    Returns a string with only digits (YYYYMMDDXXXX).
-    """
+    """Normalize Swedish personal numbers to 12 digits."""
     logger.debug("Normalizing personnummer %s", pnr)
     digits = re.sub(r"\D", "", pnr)
-    if len(digits) == 10:  # YYMMDDXXXX
+    if len(digits) == 10:
         year = int(digits[:2])
         current_year = datetime.now().year % 100
         century = datetime.now().year // 100 - (1 if year > current_year else 0)
@@ -73,254 +160,253 @@ def normalize_personnummer(pnr: str) -> str:
     return digits
 
 
+def _hash_personnummer(pnr: str) -> str:
+    """Normalize and hash a personal identity number."""
+    normalized = normalize_personnummer(pnr)
+    return hash_value(normalized)
 
 
-
-
-def create_database():
-    """Create required SQLite tables if they do not exist."""
-    logger.debug("Creating database and ensuring tables exist")
-    # Ensure the directory for the database exists, especially when using a
-    # volume-mounted path inside Docker containers.
-    db_dir = os.path.dirname(DB_PATH)
-    if db_dir:
-        os.makedirs(db_dir, exist_ok=True)
-    conn = sqlite3.connect(DB_PATH)
-    cursor = conn.cursor()
-    cursor.execute('''
-        CREATE TABLE IF NOT EXISTS pending_users (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            username TEXT NOT NULL,
-            email TEXT NOT NULL,
-            personnummer TEXT NOT NULL,
-            pdf_path TEXT NOT NULL
-        )
-    ''')
-    cursor.execute('''
-        CREATE TABLE IF NOT EXISTS users (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            username TEXT NOT NULL,
-            email TEXT NOT NULL,
-            password TEXT NOT NULL,
-            personnummer TEXT NOT NULL
-        )
-    ''')
-    conn.commit()
-    conn.close()
-    logger.info("Database initialized")
-
-def check_password_user(email, password):
+def check_password_user(email: str, password: str) -> bool:
     """Return True if ``email`` and ``password`` match a user."""
-    logger.debug("Checking password for email %s", email)
-    conn = sqlite3.connect(DB_PATH)
-    cursor = conn.cursor()
-    cursor.execute(
-        '''SELECT password FROM users WHERE email = ?''',
-        (hash_value(email),),
-    )
-    row = cursor.fetchone()
-    conn.close()
-    return bool(row and verify_password(row[0], password))
+    hashed_email = hash_value(email)
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            select(users_table.c.password).where(users_table.c.email == hashed_email)
+        ).first()
+    return bool(row and verify_password(row.password, password))
 
 
 def check_personnummer_password(personnummer: str, password: str) -> bool:
     """Return True if the hashed personnummer and password match a user."""
-    personnummer = normalize_personnummer(personnummer)
-    logger.debug("Checking login for %s", personnummer)
-    conn = sqlite3.connect(DB_PATH)
-    cursor = conn.cursor()
-    cursor.execute(
-        '''SELECT password FROM users WHERE personnummer = ?''',
-        (hash_value(personnummer),),
-    )
-    row = cursor.fetchone()
-    conn.close()
-    return bool(row and verify_password(row[0], password))
+    personnummer_hash = _hash_personnummer(personnummer)
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            select(users_table.c.password).where(
+                users_table.c.personnummer == personnummer_hash
+            )
+        ).first()
+    return bool(row and verify_password(row.password, password))
 
-def check_user_exists(email):
+
+def check_user_exists(email: str) -> bool:
     """Return True if a user with ``email`` exists."""
-    logger.debug("Checking if user exists for email %s", email)
-    conn = sqlite3.connect(DB_PATH)
-    cursor = conn.cursor()
-    cursor.execute(
-        '''SELECT * FROM users WHERE email = ?''',
-        (hash_value(email),),
-    )
-    user = cursor.fetchone()
-    conn.close()
-    return user is not None
+    hashed_email = hash_value(email)
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            select(users_table.c.id).where(users_table.c.email == hashed_email)
+        ).first()
+    return row is not None
 
-def get_username(email):
+
+def get_username(email: str) -> Optional[str]:
     """Return the username associated with ``email`` or ``None``."""
-    logger.debug("Fetching username for email %s", email)
-    conn = sqlite3.connect(DB_PATH)
-    cursor = conn.cursor()
-    cursor.execute(
-        '''SELECT username FROM users WHERE email = ?''',
-        (hash_value(email),),
-    )
-    user = cursor.fetchone()
-    conn.close()
-    return user[0] if user else None
+    hashed_email = hash_value(email)
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            select(users_table.c.username).where(users_table.c.email == hashed_email)
+        ).first()
+    return row.username if row else None
 
-def check_pending_user(personnummer):
+
+def check_pending_user(personnummer: str) -> bool:
     """Return True if a pending user with ``personnummer`` exists."""
-    personnummer = normalize_personnummer(personnummer)
-    logger.debug("Checking pending user for %s", personnummer)
-    conn = sqlite3.connect(DB_PATH)
-    cursor = conn.cursor()
-    cursor.execute(
-        '''SELECT * FROM pending_users WHERE personnummer = ?''',
-        (hash_value(personnummer),),
-    )
-    user = cursor.fetchone()
-    conn.close()
-    return user is not None
+    pnr_hash = _hash_personnummer(personnummer)
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            select(pending_users_table.c.id).where(
+                pending_users_table.c.personnummer == pnr_hash
+            )
+        ).first()
+    return row is not None
 
 
 def check_pending_user_hash(personnummer_hash: str) -> bool:
     """Return True if a pending user with ``personnummer_hash`` exists."""
-    logger.debug("Checking pending user by hash %s", personnummer_hash)
-    conn = sqlite3.connect(DB_PATH)
-    cursor = conn.cursor()
-    cursor.execute(
-        '''SELECT 1 FROM pending_users WHERE personnummer = ?''',
-        (personnummer_hash,),
-    )
-    user = cursor.fetchone()
-    conn.close()
-    return user is not None
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            select(pending_users_table.c.id).where(
+                pending_users_table.c.personnummer == personnummer_hash
+            )
+        ).first()
+    return row is not None
 
 
 @lru_cache(maxsize=256)
 def verify_certificate(personnummer: str) -> bool:
-    """Return True if a certificate for ``personnummer`` is verified.
-
-    A certificate is considered verified if the corresponding user exists in
-    the ``users`` table. Results are cached to avoid repeated database
-    lookups for the same ``personnummer``.
-    """
-    personnummer = normalize_personnummer(personnummer)
-    logger.debug("Verifying certificate for %s", personnummer)
-    conn = sqlite3.connect(DB_PATH)
-    cursor = conn.cursor()
-    cursor.execute(
-        '''SELECT 1 FROM users WHERE personnummer = ?''',
-        (hash_value(personnummer),),
-    )
-    row = cursor.fetchone()
-    conn.close()
+    """Return True if a certificate for ``personnummer`` is verified."""
+    pnr_hash = _hash_personnummer(personnummer)
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            select(users_table.c.id).where(users_table.c.personnummer == pnr_hash)
+        ).first()
     return row is not None
 
-def admin_create_user(email, username, personnummer, pdf_path):
-    """Insert a new pending user row and store the uploaded PDF(s).
 
-    ``pdf_path`` may be a single path string or an iterable of paths. Multiple
-    paths are stored as a semicolon-separated string to keep the schema
-    unchanged.
-    """
-    logger.debug("Admin creating user %s", personnummer)
-    if check_user_exists(email):
-        logger.warning("Attempt to recreate existing user %s", email)
-        return False
-
-    personnummer = normalize_personnummer(personnummer)
-    conn = sqlite3.connect(DB_PATH)
-    cursor = conn.cursor()
-    if isinstance(pdf_path, (list, tuple)):
-        pdf_path_str = ';'.join(pdf_path)
-    else:
-        pdf_path_str = pdf_path
-    cursor.execute(
-        '''
-        INSERT INTO pending_users (email, username, personnummer, pdf_path)
-        VALUES (?, ?, ?, ?)
-        ''',
-        (hash_value(email), username, hash_value(personnummer), pdf_path_str),
-    )
-    conn.commit()
-    conn.close()
+def admin_create_user(email: str, username: str, personnummer: str) -> bool:
+    """Insert a new pending user row."""
+    pnr_hash = _hash_personnummer(personnummer)
+    hashed_email = hash_value(email)
+    with get_engine().begin() as conn:
+        existing_user = conn.execute(
+            select(users_table.c.id).where(users_table.c.email == hashed_email)
+        ).first()
+        if existing_user:
+            logger.warning("Attempt to recreate existing user %s", email)
+            return False
+        existing_pending = conn.execute(
+            select(pending_users_table.c.id).where(
+                pending_users_table.c.personnummer == pnr_hash
+            )
+        ).first()
+        if existing_pending:
+            logger.warning("Pending user already exists for %s", personnummer)
+            return False
+        conn.execute(
+            insert(pending_users_table).values(
+                email=hashed_email,
+                username=username,
+                personnummer=pnr_hash,
+            )
+        )
     logger.info("Pending user created for %s", personnummer)
     return True
 
 
 def user_create_user(password: str, personnummer_hash: str) -> bool:
     """Move a pending user identified by ``personnummer_hash`` into users."""
-    logger.debug("Moving pending user %s to users", personnummer_hash)
-    conn = sqlite3.connect(DB_PATH)
-    cursor = conn.cursor()
-    try:
-        # Kontrollera om användaren redan finns
-        cursor.execute(
-            'SELECT 1 FROM users WHERE personnummer = ?',
-            (personnummer_hash,),
-        )
-        if cursor.fetchone():
+    with get_engine().begin() as conn:
+        existing = conn.execute(
+            select(users_table.c.id).where(users_table.c.personnummer == personnummer_hash)
+        ).first()
+        if existing:
             logger.warning("User %s already exists", personnummer_hash)
             return False
-
-        # Hämta användaren från pending_users
-        cursor.execute(
-            '''
-            SELECT email, username, personnummer
-            FROM pending_users
-            WHERE personnummer = ?
-            ''',
-            (personnummer_hash,),
-        )
-        row = cursor.fetchone()
+        row = conn.execute(
+            select(
+                pending_users_table.c.email,
+                pending_users_table.c.username,
+                pending_users_table.c.personnummer,
+            ).where(pending_users_table.c.personnummer == personnummer_hash)
+        ).first()
         if not row:
             logger.warning("Pending user %s not found", personnummer_hash)
             return False
-
-        email_hashed, username, pnr_hash = row
-        logger.debug("Creating user %s", username)
-
-        # Ta bort från pending_users
-        cursor.execute(
-            'DELETE FROM pending_users WHERE personnummer = ?',
-            (personnummer_hash,),
+        conn.execute(
+            delete(pending_users_table).where(
+                pending_users_table.c.personnummer == personnummer_hash
+            )
         )
-        logger.debug("Removed pending user %s", personnummer_hash)
-
-        # Lägg in i users
-        cursor.execute(
-            '''
-            INSERT INTO users (email, password, username, personnummer)
-            VALUES (?, ?, ?, ?)
-            ''',
-            (email_hashed, hash_password(password), username, pnr_hash),
+        conn.execute(
+            insert(users_table).values(
+                email=row.email,
+                password=hash_password(password),
+                username=row.username,
+                personnummer=row.personnummer,
+            )
         )
-        logger.info("User %s created", username)
-
-        conn.commit()
-        return True
-    except Exception as e:
-        conn.rollback()
-        logger.exception("Error moving pending user")
-        return False
-    finally:
-        conn.close()
+    verify_certificate.cache_clear()
+    logger.info("User %s created", row.username)
+    return True
 
 
-def get_user_info(personnummer):
+def get_user_info(personnummer: str):
     """Return database row for user identified by ``personnummer``."""
-    personnummer = normalize_personnummer(personnummer)
-    logger.debug("Fetching user info for %s", personnummer)
-    conn = sqlite3.connect(DB_PATH)
-    cursor = conn.cursor()
-    cursor.execute(
-        '''SELECT * FROM users WHERE personnummer = ?''',
-        (hash_value(personnummer),),
-    )
-    user = cursor.fetchone()
-    conn.close()
-    return user
+    pnr_hash = _hash_personnummer(personnummer)
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            select(
+                users_table.c.id,
+                users_table.c.username,
+                users_table.c.email,
+                users_table.c.password,
+                users_table.c.personnummer,
+            ).where(users_table.c.personnummer == pnr_hash)
+        ).first()
+    return row
 
-def create_test_user():
+
+def store_pdf_blob(personnummer_hash: str, filename: str, content: bytes) -> int:
+    """Store a PDF for the hashed personnummer and return its database id."""
+    with get_engine().begin() as conn:
+        result = conn.execute(
+            insert(user_pdfs_table).values(
+                personnummer=personnummer_hash,
+                filename=filename,
+                content=content,
+            )
+        )
+        pdf_id = result.inserted_primary_key[0]
+    logger.info("Stored PDF %s for %s as id %s", filename, personnummer_hash, pdf_id)
+    return int(pdf_id)
+
+
+def get_user_pdfs(personnummer_hash: str) -> List[Dict[str, Any]]:
+    """Return metadata for all PDFs belonging to ``personnummer_hash``."""
+    with get_engine().connect() as conn:
+        rows = conn.execute(
+            select(
+                user_pdfs_table.c.id,
+                user_pdfs_table.c.filename,
+                user_pdfs_table.c.uploaded_at,
+            )
+            .where(user_pdfs_table.c.personnummer == personnummer_hash)
+            .order_by(user_pdfs_table.c.uploaded_at.desc(), user_pdfs_table.c.id.desc())
+        )
+        return [
+            {
+                "id": row.id,
+                "filename": row.filename,
+                "uploaded_at": row.uploaded_at,
+            }
+            for row in rows
+        ]
+
+
+def get_pdf_metadata(personnummer_hash: str, pdf_id: int) -> Optional[Dict[str, Any]]:
+    """Return metadata for a single PDF without loading its content."""
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            select(
+                user_pdfs_table.c.id,
+                user_pdfs_table.c.filename,
+                user_pdfs_table.c.uploaded_at,
+            ).where(
+                user_pdfs_table.c.personnummer == personnummer_hash,
+                user_pdfs_table.c.id == pdf_id,
+            )
+        ).first()
+    if not row:
+        return None
+    return {
+        "id": row.id,
+        "filename": row.filename,
+        "uploaded_at": row.uploaded_at,
+    }
+
+
+def get_pdf_content(personnummer_hash: str, pdf_id: int) -> Optional[Tuple[str, bytes]]:
+    """Return the filename and binary content for ``pdf_id``."""
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            select(
+                user_pdfs_table.c.filename,
+                user_pdfs_table.c.content,
+            ).where(
+                user_pdfs_table.c.personnummer == personnummer_hash,
+                user_pdfs_table.c.id == pdf_id,
+            )
+        ).first()
+    if not row:
+        return None
+    return row.filename, row.content
+
+
+def create_test_user() -> None:
     """Populate the database with a simple test user."""
-    logger.debug("Creating test user")
     email = "test@example.com"
     username = "Test User"
     personnummer = "199001011234"
-    admin_create_user(email, username, personnummer, "dummy.pdf")
+    if not check_user_exists(email):
+        admin_create_user(email, username, personnummer)
+        pnr_hash = _hash_personnummer(personnummer)
+        user_create_user("password", pnr_hash)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ Werkzeug==3.0.6
 Jinja2==3.1.6
 itsdangerous==2.1.2
 click==8.1.7
+SQLAlchemy==2.0.29
+psycopg[binary]==3.1.18
 
 # Optional (for PDF validation if you later add more advanced checks)
 # PyPDF2==3.0.0

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -9,7 +9,11 @@
     {% if pdfs %}
     <ul class="pdf-list">
         {% for pdf in pdfs %}
-        <li><a href="{{ url_for('view_pdf', filename=pdf) }}">{{ pdf }}</a></li>
+        <li>
+            <a href="{{ url_for('view_pdf', pdf_id=pdf.id) }}">
+                {{ pdf.filename }}
+            </a>
+        </li>
         {% endfor %}
     </ul>
     {% else %}

--- a/templates/view_pdf.html
+++ b/templates/view_pdf.html
@@ -8,5 +8,5 @@
 <div class="pdf-container">
     <iframe src="{{ pdf_url }}" title="{{ filename }}" frameborder="0"></iframe>
 </div>
-<p><a href="{{ url_for('download_pdf', filename=filename) }}">Ladda ner PDF</a></p>
+<p><a href="{{ url_for('download_pdf', pdf_id=pdf_id) }}">Ladda ner PDF</a></p>
 {% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,61 +1,47 @@
 import os
 import sys
-import sqlite3
+
 import pytest
 import werkzeug
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-import app
-import functions
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+import app  # noqa: E402
+import functions  # noqa: E402
 
 if not hasattr(werkzeug, "__version__"):
     werkzeug.__version__ = "3.0.0"
 
 
-@pytest.fixture
-def user_db(tmp_path, monkeypatch):
-    """Create a temporary DB with a default user and patch connections."""
-    db_path = tmp_path / "test.db"
-    real_connect = sqlite3.connect
-
-    def connect_stub(_):
-        return real_connect(db_path)
-
-    monkeypatch.setattr(app.functions.sqlite3, "connect", connect_stub)
-    monkeypatch.setattr(functions.sqlite3, "connect", connect_stub)
-    app.app.secret_key = "test-secret"
+def _prepare_database(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    db_url = f"sqlite:///{tmp_path / 'test.db'}"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    functions.reset_engine()
     functions.create_database()
-
-    conn = real_connect(db_path)
-    cursor = conn.cursor()
-    cursor.execute(
-        "INSERT INTO users (username, email, password, personnummer) VALUES (?, ?, ?, ?)",
-        (
-            "Test",
-            functions.hash_value("test@example.com"),
-            functions.hash_password("secret"),
-            functions.hash_value("199001011234"),
-        ),
-    )
-    conn.commit()
-    conn.close()
-
-    return db_path
+    app.app.secret_key = "test-secret"
 
 
 @pytest.fixture
 def empty_db(tmp_path, monkeypatch):
-    """Create an empty temporary DB and patch connections."""
-    db_path = tmp_path / "test.db"
-    real_connect = sqlite3.connect
+    """Provide a fresh empty database for a test."""
+    _prepare_database(monkeypatch, tmp_path)
+    return functions.get_engine()
 
-    def connect_stub(_):
-        return real_connect(db_path)
 
-    monkeypatch.setattr(app.functions.sqlite3, "connect", connect_stub)
-    monkeypatch.setattr(functions.sqlite3, "connect", connect_stub)
-    app.app.secret_key = "test-secret"
-    functions.create_database()
-
-    return db_path
+@pytest.fixture
+def user_db(tmp_path, monkeypatch):
+    """Provide a database pre-populated with a default user."""
+    _prepare_database(monkeypatch, tmp_path)
+    engine = functions.get_engine()
+    with engine.begin() as conn:
+        conn.execute(
+            functions.users_table.insert().values(
+                username="Test",
+                email=functions.hash_value("test@example.com"),
+                password=functions.hash_password("secret"),
+                personnummer=functions.hash_value("199001011234"),
+            )
+        )
+    return engine

--- a/tests/test_admin_upload.py
+++ b/tests/test_admin_upload.py
@@ -1,25 +1,27 @@
 import io
-import sqlite3
+
 import app
 import functions
 
 
-def test_admin_upload_existing_user_only_saves_pdf(empty_db, tmp_path, monkeypatch):
-    monkeypatch.setitem(app.app.config, "UPLOAD_ROOT", tmp_path)
+def _admin_client():
+    client = app.app.test_client()
+    with client.session_transaction() as sess:
+        sess["admin_logged_in"] = True
+    return client
 
-    conn = sqlite3.connect(empty_db)
-    cursor = conn.cursor()
-    cursor.execute(
-        "INSERT INTO users (username, email, password, personnummer) VALUES (?, ?, ?, ?)",
-        (
-            "Existing",
-            functions.hash_value("exist@example.com"),
-            functions.hash_password("secret"),
-            functions.hash_value("199001011234"),
-        ),
-    )
-    conn.commit()
-    conn.close()
+
+def test_admin_upload_existing_user_only_saves_pdf(empty_db):
+    engine = empty_db
+    with engine.begin() as conn:
+        conn.execute(
+            functions.users_table.insert().values(
+                username="Existing",
+                email=functions.hash_value("exist@example.com"),
+                password=functions.hash_password("secret"),
+                personnummer=functions.hash_value("199001011234"),
+            )
+        )
 
     pdf_bytes = b"%PDF-1.4 test"
     data = {
@@ -29,30 +31,35 @@ def test_admin_upload_existing_user_only_saves_pdf(empty_db, tmp_path, monkeypat
         "pdf": (io.BytesIO(pdf_bytes), "doc.pdf"),
     }
 
-    with app.app.test_client() as client:
-        with client.session_transaction() as sess:
-            sess["admin_logged_in"] = True
+    with _admin_client() as client:
         response = client.post("/admin", data=data, content_type="multipart/form-data")
-        assert response.status_code == 200
-        assert response.get_json()["status"] == "success"
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "success"
+
+    pnr_hash = functions.hash_value("199001011234")
+    with engine.connect() as conn:
+        rows = list(
+            conn.execute(
+                functions.user_pdfs_table.select().where(
+                    functions.user_pdfs_table.c.personnummer == pnr_hash
+                )
+            )
+        )
+    assert len(rows) == 1
+    assert rows[0].content == pdf_bytes
 
 
-def test_admin_upload_existing_email(tmp_path, empty_db, monkeypatch):
-    monkeypatch.setitem(app.app.config, "UPLOAD_ROOT", tmp_path)
-
-    conn = sqlite3.connect(empty_db)
-    cursor = conn.cursor()
-    cursor.execute(
-        "INSERT INTO users (username, email, password, personnummer) VALUES (?, ?, ?, ?)",
-        (
-            "Existing",
-            functions.hash_value("exist@example.com"),
-            functions.hash_password("secret"),
-            functions.hash_value("199001011234"),
-        ),
-    )
-    conn.commit()
-    conn.close()
+def test_admin_upload_existing_email(empty_db):
+    engine = empty_db
+    with engine.begin() as conn:
+        conn.execute(
+            functions.users_table.insert().values(
+                username="Existing",
+                email=functions.hash_value("exist@example.com"),
+                password=functions.hash_password("secret"),
+                personnummer=functions.hash_value("199001011234"),
+            )
+        )
 
     pdf_bytes = b"%PDF-1.4 test"
     data = {
@@ -62,14 +69,19 @@ def test_admin_upload_existing_email(tmp_path, empty_db, monkeypatch):
         "pdf": (io.BytesIO(pdf_bytes), "doc.pdf"),
     }
 
-    with app.app.test_client() as client:
-        with client.session_transaction() as sess:
-            sess["admin_logged_in"] = True
+    with _admin_client() as client:
         response = client.post("/admin", data=data, content_type="multipart/form-data")
-        assert response.status_code == 200
-        assert response.get_json()["status"] == "success"
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "success"
 
-    pnr_hash = functions.hash_value(functions.normalize_personnummer("20000101-9999"))
-    saved_dir = tmp_path / pnr_hash
-    assert saved_dir.exists()
-    assert any(p.suffix == ".pdf" for p in saved_dir.iterdir())
+    new_hash = functions.hash_value(functions.normalize_personnummer("20000101-9999"))
+    with engine.connect() as conn:
+        rows = list(
+            conn.execute(
+                functions.user_pdfs_table.select().where(
+                    functions.user_pdfs_table.c.personnummer == new_hash
+                )
+            )
+        )
+    assert len(rows) == 1
+    assert rows[0].content == pdf_bytes

--- a/tests/test_certificate_verification.py
+++ b/tests/test_certificate_verification.py
@@ -1,37 +1,21 @@
 import os
-import sqlite3
 import sys
-import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-import app
-import functions
+
+import app  # noqa: E402
+import functions  # noqa: E402
 
 
-def setup_db(tmp_path, monkeypatch):
-    db_path = tmp_path / "test.db"
-    real_connect = sqlite3.connect
-    calls = {"count": 0}
-
-    def connect_stub(_):
-        calls["count"] += 1
-        return real_connect(db_path)
-
-    monkeypatch.setattr(functions.sqlite3, "connect", connect_stub)
-    monkeypatch.setattr(app.functions, "sqlite3", functions.sqlite3)
-    app.app.secret_key = "test-secret"
-    functions.create_database()
-    calls["count"] = 0
-    return db_path, calls
-
-
-def test_verify_certificate_caching_and_message(tmp_path, monkeypatch):
-    _, calls = setup_db(tmp_path, monkeypatch)
+def test_verify_certificate_caching_and_message(empty_db, monkeypatch):
     functions.verify_certificate.cache_clear()
+    assert not functions.verify_certificate("19900101-1234")
 
+    def fail_get_engine():
+        raise AssertionError("verify_certificate should use cached value")
+
+    monkeypatch.setattr(functions, "get_engine", fail_get_engine)
     assert not functions.verify_certificate("19900101-1234")
-    assert not functions.verify_certificate("19900101-1234")
-    assert calls["count"] == 1
 
     with app.app.test_client() as client:
         with client.session_transaction() as sess:
@@ -39,5 +23,3 @@ def test_verify_certificate_caching_and_message(tmp_path, monkeypatch):
         response = client.get("/verify_certificate/19900101-1234")
         assert response.status_code == 404
         assert "inte verifierat" in response.get_data(as_text=True).lower()
-        # No additional DB call due to caching
-        assert calls["count"] == 1

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -2,16 +2,27 @@ import app
 import functions
 
 
-def test_dashboard_shows_only_user_pdfs(user_db, tmp_path, monkeypatch):
-    monkeypatch.setitem(app.app.config, "UPLOAD_ROOT", tmp_path)
+def test_dashboard_shows_only_user_pdfs(user_db):
+    engine = user_db
+    own_hash = functions.hash_value("199001011234")
+    other_hash = functions.hash_value("200001011234")
 
-    user_dir = tmp_path / functions.hash_value("199001011234")
-    user_dir.mkdir()
-    (user_dir / "own.pdf").write_text("test")
-
-    other_dir = tmp_path / functions.hash_value("200001011234")
-    other_dir.mkdir()
-    (other_dir / "other.pdf").write_text("test")
+    with engine.begin() as conn:
+        conn.execute(
+            functions.user_pdfs_table.insert(),
+            [
+                {
+                    "personnummer": own_hash,
+                    "filename": "own.pdf",
+                    "content": b"%PDF-1.4 own",
+                },
+                {
+                    "personnummer": other_hash,
+                    "filename": "other.pdf",
+                    "content": b"%PDF-1.4 other",
+                },
+            ],
+        )
 
     with app.app.test_client() as client:
         client.post("/login", data={"personnummer": "199001011234", "password": "secret"})

--- a/tests/test_docker_files.py
+++ b/tests/test_docker_files.py
@@ -25,17 +25,18 @@ def test_dockerfile_exposes_port_and_runs_entrypoint():
     assert 'CMD ["./entrypoint.sh"]' in dockerfile
 
 
-def test_compose_maps_port_and_sets_db_path():
+def test_compose_maps_ports_and_sets_database_url():
     compose = _read(ROOT / "docker-compose.yml")
     # Acceptera klassiskt 1:1 eller mappning till högre portar i containern
     assert re.search(r"-\s*\"80:(80|8080)\"", compose)
     assert re.search(r"-\s*\"443:(443|8443)\"", compose)
-    assert "DB_PATH: /data/database.db" in compose
+    assert "DATABASE_URL: postgresql+psycopg://" in compose
+    assert "image: postgres" in compose
 
 
-def test_compose_mounts_config_volume():
+def test_compose_avoids_host_volumes():
     compose = _read(ROOT / "docker-compose.yml")
-    assert "- env_data:/config" in compose
+    assert "volumes:" not in compose or "- env_data:/config" not in compose
 
 
 def test_entrypoint_uses_nginx():

--- a/tests/test_functions_additional.py
+++ b/tests/test_functions_additional.py
@@ -1,57 +1,54 @@
 import os
 import sys
-import sqlite3
+
 import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-import functions
 
-@pytest.fixture
-def db(monkeypatch, tmp_path):
-    db_path = tmp_path / 'test.db'
-    real_connect = sqlite3.connect
-    def connect_stub(_):
-        return real_connect(db_path)
-    monkeypatch.setattr(functions, 'DB_PATH', str(db_path))
-    monkeypatch.setattr(functions.sqlite3, 'connect', connect_stub)
-    functions.create_database()
-    return db_path
+import functions  # noqa: E402
 
-def test_normalize_personnummer(db):
-    assert functions.normalize_personnummer('19900101-1234') == '199001011234'
-    assert functions.normalize_personnummer('199001011234') == '199001011234'
-    assert functions.normalize_personnummer('9001011234') == '199001011234'
+
+def test_normalize_personnummer():
+    assert functions.normalize_personnummer("19900101-1234") == "199001011234"
+    assert functions.normalize_personnummer("199001011234") == "199001011234"
+    assert functions.normalize_personnummer("9001011234") == "199001011234"
     with pytest.raises(ValueError):
-        functions.normalize_personnummer('123')
+        functions.normalize_personnummer("123")
 
-def test_admin_and_user_create_flow(db, monkeypatch):
-    email = 'new@example.com'
-    username = 'New'
-    personnummer = '19900101-1234'
-    pdfs = ['a.pdf', 'b.pdf']
-    assert functions.admin_create_user(email, username, personnummer, pdfs)
 
-    conn = sqlite3.connect(db)
-    cursor = conn.cursor()
-    cursor.execute('SELECT email, pdf_path FROM pending_users')
-    row = cursor.fetchone()
-    conn.close()
-    assert row[0] == functions.hash_value(email)
-    assert row[1] == 'a.pdf;b.pdf'
-    assert not functions.check_user_exists(email)
+def test_admin_and_user_create_flow(empty_db, monkeypatch):
+    email = "new@example.com"
+    username = "New"
+    personnummer = "19900101-1234"
+
+    assert functions.admin_create_user(email, username, personnummer)
+
+    with empty_db.connect() as conn:
+        pending_row = conn.execute(functions.pending_users_table.select()).first()
+    assert pending_row is not None
+    assert pending_row.email == functions.hash_value(email)
+    assert pending_row.username == username
 
     pnr_hash = functions.hash_value(functions.normalize_personnummer(personnummer))
-    assert functions.user_create_user('secret', pnr_hash)
+    assert functions.user_create_user("secret", pnr_hash)
     assert functions.check_user_exists(email)
 
-    functions.verify_certificate.cache_clear()
-    calls = {'count': 0}
-    real_connect = sqlite3.connect
-    def connect_count(_):
-        calls['count'] += 1
-        return real_connect(db)
-    monkeypatch.setattr(functions.sqlite3, 'connect', connect_count)
+    with empty_db.connect() as conn:
+        pending_after = conn.execute(functions.pending_users_table.select()).first()
+        user_row = conn.execute(
+            functions.users_table.select().where(
+                functions.users_table.c.personnummer == pnr_hash
+            )
+        ).first()
 
+    assert pending_after is None
+    assert user_row is not None
+
+    functions.verify_certificate.cache_clear()
     assert functions.verify_certificate(personnummer)
+
+    def fail_get_engine():
+        raise AssertionError("verify_certificate should use cached value")
+
+    monkeypatch.setattr(functions, "get_engine", fail_get_engine)
     assert functions.verify_certificate(personnummer)
-    assert calls['count'] == 1

--- a/tests/test_functions_more.py
+++ b/tests/test_functions_more.py
@@ -1,57 +1,46 @@
 import os
 import sys
-import sqlite3
-import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-import functions
 
-@pytest.fixture
-def tmp_db(tmp_path, monkeypatch):
-    db_path = tmp_path / "test.db"
-    real_connect = sqlite3.connect
-    def connect_stub(_):
-        return real_connect(db_path)
-    monkeypatch.setattr(functions, "DB_PATH", str(db_path))
-    monkeypatch.setattr(functions.sqlite3, "connect", connect_stub)
-    functions.create_database()
-    return db_path
+import functions  # noqa: E402
 
-def test_check_pending_user_hash_missing(tmp_db):
+
+def test_check_pending_user_hash_missing(empty_db):
     assert not functions.check_pending_user_hash("missinghash")
 
-def test_admin_create_user_single_pdf(tmp_db):
+
+def test_admin_create_user_single_pdf(empty_db):
     email = "user@example.com"
     username = "User"
     pnr = "19900101-1234"
-    pdf = "doc.pdf"
-    assert functions.admin_create_user(email, username, pnr, pdf)
-    conn = sqlite3.connect(tmp_db)
-    cursor = conn.cursor()
-    cursor.execute("SELECT email, pdf_path FROM pending_users")
-    row = cursor.fetchone()
-    conn.close()
-    assert row[0] == functions.hash_value(email)
-    assert row[1] == pdf
+    assert functions.admin_create_user(email, username, pnr)
+    with empty_db.connect() as conn:
+        row = conn.execute(functions.pending_users_table.select()).first()
+    assert row.email == functions.hash_value(email)
+    assert row.username == username
 
-def test_check_password_user_nonexistent(tmp_db):
+
+def test_check_password_user_nonexistent(empty_db):
     assert not functions.check_password_user("no@example.com", "secret")
 
-def test_get_username_nonexistent(tmp_db):
+
+def test_get_username_nonexistent(empty_db):
     assert functions.get_username("no@example.com") is None
 
-def test_create_database_creates_tables(tmp_db):
-    conn = sqlite3.connect(tmp_db)
-    cursor = conn.cursor()
-    for table in ["pending_users", "users"]:
-        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,))
-        assert cursor.fetchone() is not None
-    conn.close()
 
-def test_verify_certificate_not_found(tmp_db):
+def test_create_database_creates_tables(empty_db):
+    with empty_db.connect() as conn:
+        for table in [functions.pending_users_table, functions.users_table, functions.user_pdfs_table]:
+            result = conn.execute(table.select().limit(0))
+            assert result is not None
+
+
+def test_verify_certificate_not_found(empty_db):
     functions.verify_certificate.cache_clear()
     assert not functions.verify_certificate("19900101-1234")
 
-def test_user_create_user_no_pending(tmp_db):
+
+def test_user_create_user_no_pending(empty_db):
     pnr_hash = functions.hash_value("199001011234")
     assert not functions.user_create_user("pass", pnr_hash)

--- a/tests/test_save_pdf.py
+++ b/tests/test_save_pdf.py
@@ -1,19 +1,20 @@
 import io
 import os
 import sys
+
 import pytest
 import werkzeug
 
 if not hasattr(werkzeug, "__version__"):
     werkzeug.__version__ = "3.0.0"
 
-# Ensure project root on path
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-import app
-from app import save_pdf_for_user, APP_ROOT
+import app  # noqa: E402
+import functions  # noqa: E402
+from app import save_pdf_for_user  # noqa: E402
 from werkzeug.datastructures import FileStorage
 
 
@@ -22,17 +23,26 @@ def _file_storage(data: bytes, filename: str, mimetype: str = "application/pdf")
     return FileStorage(stream=io.BytesIO(data), filename=filename, content_type=mimetype)
 
 
-def test_save_pdf_removes_personnummer_from_filename(tmp_path, monkeypatch):
-    monkeypatch.setitem(app.app.config, "UPLOAD_ROOT", tmp_path)
+def test_save_pdf_stores_in_database(empty_db):
     pdf = _file_storage(b"%PDF-1.4 test", "199001011234_resume.pdf")
-    rel = save_pdf_for_user("199001011234", pdf)
-    abs_path = os.path.join(APP_ROOT, rel)
-    assert os.path.exists(abs_path)
-    assert "199001011234" not in os.path.basename(rel)
+    result = save_pdf_for_user("199001011234", pdf)
+
+    assert "id" in result and "filename" in result
+    assert "199001011234" not in result["filename"]
+
+    with functions.get_engine().connect() as conn:
+        row = conn.execute(
+            functions.user_pdfs_table.select().where(
+                functions.user_pdfs_table.c.id == result["id"]
+            )
+        ).first()
+    assert row is not None
+    assert row.filename == result["filename"]
+    assert row.personnummer == functions.hash_value("199001011234")
+    assert row.content.startswith(b"%PDF-")
 
 
-def test_save_pdf_rejects_invalid_files(tmp_path, monkeypatch):
-    monkeypatch.setitem(app.app.config, "UPLOAD_ROOT", tmp_path)
+def test_save_pdf_rejects_invalid_files(empty_db):
     not_pdf = _file_storage(b"not pdf", "doc.pdf")
     with pytest.raises(ValueError):
         save_pdf_for_user("199001011234", not_pdf)

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -1,65 +1,51 @@
-import sqlite3
 import os
 import sys
-import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-import functions
+
+import functions  # noqa: E402
 
 
-@pytest.fixture
-def tmp_db(tmp_path, monkeypatch):
-    db_path = tmp_path / "test.db"
-    real_connect = sqlite3.connect
-
-    def connect_stub(_):
-        return real_connect(db_path)
-
-    monkeypatch.setattr(functions, "DB_PATH", str(db_path))
-    monkeypatch.setattr(functions.sqlite3, "connect", connect_stub)
-    functions.create_database()
-    return db_path
-
-
-def test_check_user_exists(tmp_db):
+def test_check_user_exists(empty_db):
     email = "exists@example.com"
-    conn = sqlite3.connect(tmp_db)
-    cursor = conn.cursor()
-    cursor.execute(
-        "INSERT INTO users (username, email, password, personnummer) VALUES (?, ?, ?, ?)",
-        (
-            "Exists",
-            functions.hash_value(email),
-            functions.hash_password("pass"),
-            functions.hash_value("199001011234"),
-        ),
-    )
-    conn.commit()
-    conn.close()
+    with empty_db.begin() as conn:
+        conn.execute(
+            functions.users_table.insert().values(
+                username="Exists",
+                email=functions.hash_value(email),
+                password=functions.hash_password("pass"),
+                personnummer=functions.hash_value("199001011234"),
+            )
+        )
 
     assert functions.check_user_exists(email)
     assert not functions.check_user_exists("missing@example.com")
 
 
-def test_user_create_user_success(tmp_db):
+def test_user_create_user_success(empty_db):
     email = "new@example.com"
     username = "NewUser"
     personnummer = "19900101-1234"
-    pdf_path = "doc.pdf"
 
-    assert functions.admin_create_user(email, username, personnummer, pdf_path)
+    assert functions.admin_create_user(email, username, personnummer)
 
     pnr_hash = functions.hash_value(functions.normalize_personnummer(personnummer))
     assert functions.user_create_user("secret", pnr_hash)
 
-    conn = sqlite3.connect(tmp_db)
-    cursor = conn.cursor()
-    cursor.execute("SELECT 1 FROM pending_users WHERE personnummer = ?", (pnr_hash,))
-    assert cursor.fetchone() is None
-    cursor.execute("SELECT email, username FROM users WHERE personnummer = ?", (pnr_hash,))
-    row = cursor.fetchone()
-    conn.close()
+    with empty_db.connect() as conn:
+        pending = conn.execute(
+            functions.pending_users_table.select().where(
+                functions.pending_users_table.c.personnummer == pnr_hash
+            )
+        ).first()
+        user_row = conn.execute(
+            functions.users_table.select().where(
+                functions.users_table.c.personnummer == pnr_hash
+            )
+        ).first()
 
-    assert row == (functions.hash_value(email), username)
+    assert pending is None
+    assert user_row is not None
+    assert user_row.email == functions.hash_value(email)
+    assert user_row.username == username
     assert functions.check_user_exists(email)
-

--- a/tests/test_user_queries.py
+++ b/tests/test_user_queries.py
@@ -1,68 +1,38 @@
 import os
-import sqlite3
 import sys
-
-import pytest
 
 # Ensure project root on path
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-import functions
+import functions  # noqa: E402
 
 
-@pytest.fixture
-def tmp_db(tmp_path, monkeypatch):
-    """Create a temporary database and patch sqlite3 to use it."""
-    db_path = tmp_path / "test.db"
-    real_connect = sqlite3.connect
-
-    def connect_stub(_):
-        return real_connect(db_path)
-
-    monkeypatch.setattr(functions, "DB_PATH", str(db_path))
-    monkeypatch.setattr(functions.sqlite3, "connect", connect_stub)
-    functions.create_database()
+def test_verify_certificate_existing_user(empty_db):
+    with empty_db.begin() as conn:
+        conn.execute(
+            functions.users_table.insert().values(
+                username="Test",
+                email=functions.hash_value("user@example.com"),
+                password=functions.hash_password("secret"),
+                personnummer=functions.hash_value("199001011234"),
+            )
+        )
     functions.verify_certificate.cache_clear()
-    return db_path
-
-
-def test_verify_certificate_existing_user(tmp_db):
-    """verify_certificate should return True when a user exists."""
-    conn = sqlite3.connect(tmp_db)
-    cursor = conn.cursor()
-    cursor.execute(
-        "INSERT INTO users (username, email, password, personnummer) VALUES (?, ?, ?, ?)",
-        (
-            "Test",
-            functions.hash_value("user@example.com"),
-            functions.hash_password("secret"),
-            functions.hash_value("199001011234"),
-        ),
-    )
-    conn.commit()
-    conn.close()
-
     assert functions.verify_certificate("199001011234")
 
 
-def test_check_user_exists(tmp_db):
-    """check_user_exists should detect whether an email is registered."""
+def test_check_user_exists(empty_db):
     email = "tester@example.com"
-    conn = sqlite3.connect(tmp_db)
-    cursor = conn.cursor()
-    cursor.execute(
-        "INSERT INTO users (username, email, password, personnummer) VALUES (?, ?, ?, ?)",
-        (
-            "Tester",
-            functions.hash_value(email),
-            functions.hash_password("pass"),
-            functions.hash_value("199001011234"),
-        ),
-    )
-    conn.commit()
-    conn.close()
-
+    with empty_db.begin() as conn:
+        conn.execute(
+            functions.users_table.insert().values(
+                username="Tester",
+                email=functions.hash_value(email),
+                password=functions.hash_password("pass"),
+                personnummer=functions.hash_value("199001011234"),
+            )
+        )
     assert functions.check_user_exists(email)
     assert not functions.check_user_exists("unknown@example.com")


### PR DESCRIPTION
## Summary
- replace the old sqlite helpers with a SQLAlchemy engine that creates PostgreSQL-friendly tables, including a user_pdfs table for binary certificate storage
- update the Flask views to store and retrieve PDFs from the database, adjust dashboard/download routes, and refresh the dashboard/view templates
- add a PostgreSQL service to docker-compose and update the test fixtures/test cases to exercise the new database-backed workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c853f08900832daff3cfbf6042f6ef