### PR TITLE
Load database configuration from .env

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -19,7 +19,12 @@ secret_key=your_secret_key
 # Salt used for hashing personal data such as email and personnummer
 HASH_SALT=choose_a_good_salt
 
-# Path to the SQLite database file
+# Database configuration
+# Use DATABASE_URL to reference an existing Postgres instance (another
+# container, managed database, etc.). The docker-compose setup expects this to
+# be defined and will pass it through to the application container.
+DATABASE_URL=postgresql+psycopg://appuser:apppassword@your-postgres-host:5432/appdb
+# When DATABASE_URL is omitted the application falls back to a local SQLite file.
 DB_PATH=/data/database.db
 
 # Optional: TLS certificate and key for HTTPS

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This web application manages the issuance and storage of course certificates. It
    source venv/bin/activate
    pip install -r requirements.txt
    ```
-2. **Configure environment variables** – copy `.example.env` to `.env` and update the values to match your setup.
+2. **Configure environment variables** – copy `.example.env` to `.env` and update the values to match your setup. Set `DATABASE_URL` to the connection string for your Postgres instance (for example `postgresql+psycopg://user:password@hostname:5432/database`). The Docker Compose configuration simply forwards this value to the application container so you can point at an existing database. If you omit `DATABASE_URL` the application falls back to the SQLite database referenced by `DB_PATH`.
 3. **Run the application**
    ```bash
    python app.py

--- a/app.py
+++ b/app.py
@@ -30,14 +30,14 @@ from flask import (
     url_for,
 )
 from werkzeug.utils import secure_filename
-from dotenv import load_dotenv
+
+from config_loader import load_environment
+
+
+load_environment()
 
 import functions
 
-
-APP_ROOT = os.path.abspath(os.path.dirname(__file__))
-CONFIG_PATH = os.getenv("CONFIG_PATH", "/config/.env")
-load_dotenv(CONFIG_PATH)
 ALLOWED_MIMES = {'application/pdf'}
 
 logger = logging.getLogger(__name__)

--- a/config_loader.py
+++ b/config_loader.py
@@ -1,0 +1,57 @@
+"""Utilities for loading environment variables from configuration files."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable
+
+from dotenv import load_dotenv
+
+
+def _resolve_unique_paths(paths: Iterable[str | os.PathLike[str] | None]) -> list[Path]:
+    """Return a list of unique, expanded ``Path`` objects from ``paths``."""
+
+    resolved_paths: list[Path] = []
+    seen: set[Path] = set()
+
+    for raw in paths:
+        if not raw:
+            continue
+
+        path = Path(raw).expanduser()
+        try:
+            canonical = path.resolve()
+        except FileNotFoundError:
+            canonical = path
+
+        if canonical in seen:
+            continue
+
+        seen.add(canonical)
+        resolved_paths.append(path)
+
+    return resolved_paths
+
+
+def load_environment() -> None:
+    """Load environment variables from available configuration files."""
+
+    app_root = Path(__file__).resolve().parent
+    candidates = _resolve_unique_paths(
+        (
+            os.getenv("CONFIG_PATH"),
+            Path("/config/.env"),
+            app_root / ".env",
+        )
+    )
+
+    loaded = False
+    for path in candidates:
+        if path.is_file():
+            load_dotenv(path, override=False)
+            loaded = True
+
+    if not loaded:
+        load_dotenv(override=False)
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,7 @@
 version: '3.9'
 services:
-  db:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_USER: appuser
-      POSTGRES_PASSWORD: apppassword
-      POSTGRES_DB: appdb
   app:
     build: .
-    depends_on:
-      - db
     ports:
       - "80:80"
       - "443:443"
@@ -17,4 +9,4 @@ services:
     env_file:
       - .env
     environment:
-      DATABASE_URL: postgresql+psycopg://appuser:apppassword@db:5432/appdb
+      DATABASE_URL: "${DATABASE_URL:?Set DATABASE_URL in .env to point at your Postgres instance}"

--- a/functions.py
+++ b/functions.py
@@ -10,7 +10,6 @@ from datetime import datetime
 from functools import lru_cache
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from dotenv import load_dotenv
 from sqlalchemy import (
     Column,
     DateTime,
@@ -30,11 +29,13 @@ from sqlalchemy.engine.url import make_url
 from sqlalchemy.pool import StaticPool
 from werkzeug.security import check_password_hash, generate_password_hash
 
+from config_loader import load_environment
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)  # or INFO in production
 logger.propagate = True
 
-load_dotenv(os.getenv("CONFIG_PATH", "/config/.env"))
+load_environment()
 
 APP_ROOT = os.path.abspath(os.path.dirname(__file__))
 logger.debug("Application root directory: %s", APP_ROOT)

--- a/tests/test_docker_files.py
+++ b/tests/test_docker_files.py
@@ -25,13 +25,15 @@ def test_dockerfile_exposes_port_and_runs_entrypoint():
     assert 'CMD ["./entrypoint.sh"]' in dockerfile
 
 
-def test_compose_maps_ports_and_sets_database_url():
+def test_compose_maps_ports_and_requires_external_database():
     compose = _read(ROOT / "docker-compose.yml")
     # Acceptera klassiskt 1:1 eller mappning till högre portar i containern
     assert re.search(r"-\s*\"80:(80|8080)\"", compose)
     assert re.search(r"-\s*\"443:(443|8443)\"", compose)
-    assert "DATABASE_URL: postgresql+psycopg://" in compose
-    assert "image: postgres" in compose
+    assert "DATABASE_URL" in compose
+    assert "image: postgres" not in compose
+    assert re.search(r"^\s{2}db:\s*$", compose, re.MULTILINE) is None
+    assert "@db:5432" not in compose
 
 
 def test_compose_avoids_host_volumes():


### PR DESCRIPTION
## Summary
- add a reusable loader that pulls configuration from .env files or CONFIG_PATH
- initialize the Flask app and database helpers through the shared loader so DATABASE_URL comes from .env values by default
- document the database URL setting, update the example environment file, and let docker-compose defer to .env overrides
- remove the bundled Postgres service from docker-compose so DATABASE_URL can target an existing database container

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c86511bcfc832dae3a5b96b2e83e94