### PR TITLE
Fix bundled Postgres init password file ownership

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,6 +41,9 @@ start_bundled_postgres() {
     echo "Initializing bundled PostgreSQL data directory at ${POSTGRES_DATA_DIR}"
     PASSFILE=$(mktemp)
     printf '%s\n' "${POSTGRES_PASSWORD}" > "${PASSFILE}"
+    # Make the password file readable by the postgres user (mktemp creates it for root).
+    chown postgres:postgres "${PASSFILE}"
+    chmod 600 "${PASSFILE}"
     su-exec postgres:postgres sh -c "initdb -D \"${POSTGRES_DATA_DIR}\" -U \"${POSTGRES_USER}\" --auth=scram-sha-256 --pwfile=\"${PASSFILE}\""
     rm -f "${PASSFILE}"
   else


### PR DESCRIPTION
## Summary
- ensure the temporary password file used during bundled PostgreSQL initialization is owned by the postgres user so initdb can read it

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c883bb95d0832d9a3ebf4870c88907