### PR TITLE
Clarify Swedish language requirement for user-facing text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,4 @@
 - Follow PEP8 coding conventions.
 - Ensure commit messages are descriptive.
 - Do not commit sensitive information.
+- Everything displayed to end users must be written in Swedish.


### PR DESCRIPTION
## Summary
- update AGENTS.md to require all user-facing content to be written in Swedish

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd618ae780832da3854253166d0099