### PR TITLE
Add concrete sample values to example env file

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -2,40 +2,41 @@
 # Copy this file to `.env` and adjust the values for your environment.
 
 # SMTP server settings used to send account activation emails
-# Use port 587 for STARTTLS or 465 for SSL
+# Use port 587 for STARTTLS or 465 for SSL. The example below shows how to
+# configure a Gmail account that has an app password enabled.
 smtp_port=587
-smtp_server=smtp.example.com
-smtp_user=your_email@example.com
-smtp_password=your_password
+smtp_server=smtp.gmail.com
+smtp_user=utbildning.demo@gmail.com
+smtp_password=bytMig123!
 smtp_timeout=10
 
 # Administrator credentials for the admin panel
-admin_username=your_admin_username
-admin_password=your_admin_password
+admin_username=utbildningsadmin
+admin_password=SakertLosen123!
 
 # Secret key used by Flask to secure sessions
-secret_key=your_secret_key
+secret_key=hemligt_session_varde
 
 # Salt used for hashing personal data such as email and personnummer
-HASH_SALT=choose_a_good_salt
+HASH_SALT=extra_salt_for_hash
 
 # Database configuration
 # Supply credentials for the external PostgreSQL server that stores
 # application data. POSTGRES_HOST is required when DATABASE_URL is empty.
-POSTGRES_HOST=postgres.example.com
-POSTGRES_DB=appdb
-POSTGRES_USER=appuser
-POSTGRES_PASSWORD=change_me
+POSTGRES_HOST=db.example.se
+POSTGRES_DB=utbildningsintyg
+POSTGRES_USER=jk_admin
+POSTGRES_PASSWORD=BytMigDirekt
 POSTGRES_PORT=5432
 # Alternatively provide a full SQLAlchemy connection string if you prefer.
 # When set, DATABASE_URL takes precedence over the POSTGRES_* values.
-DATABASE_URL=
+DATABASE_URL=postgresql+psycopg2://jk_admin:BytMigDirekt@db.example.se:5432/utbildningsintyg
 
 # Optional: TLS certificate and key for HTTPS
 # Paste the PEM contents directly. Use \n for newlines if necessary.
 # When both values are provided the application will start with HTTPS.
-TLS_CERT=
-TLS_KEY=
+TLS_CERT=-----BEGIN CERTIFICATE-----\nMIIDgzCCAmugAwIBAgIUVdDemoCert1234567890\n-----END CERTIFICATE-----
+TLS_KEY=-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcw\n-----END PRIVATE KEY-----
 
 # Enable debug mode for development
 FLASK_DEBUG=False


### PR DESCRIPTION
## Summary
- replace placeholder values in `.example.env` with realistic temporary example credentials
- document sample SMTP, admin, database, and TLS settings to guide local configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd6ae4158c832d9a898d82a3ed4bd0