### PR TITLE
Default to production ports in entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,8 +22,8 @@ shutdown() {
 trap 'shutdown' INT TERM EXIT
 
 # Standardportar i containern (mappa utanför)
-HTTPS_PORT="${HTTPS_PORT:-8443}"
-HTTP_PORT="${HTTP_PORT:-8080}"
+HTTPS_PORT="${HTTPS_PORT:-443}"
+HTTP_PORT="${HTTP_PORT:-80}"
 FLASK_PORT="${FLASK_PORT:-5000}"
 
 # TLS källor:


### PR DESCRIPTION
## Summary
- update the entrypoint script so nginx listens on ports 80 and 443 by default

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd72e69d44832da75603e5702d61a5