### PR TITLE
Hantera escapade radbrytningar i TLS-certifikat

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,12 +39,13 @@ write_tls_from_env() {
   # Skriv från TLS_CERT/TLS_KEY (PEM eller base64)
   if [ -n "${TLS_CERT:-}" ] && [ -n "${TLS_KEY:-}" ]; then
     if echo "$TLS_CERT" | grep -q "BEGIN CERTIFICATE"; then
-      printf '%s' "$TLS_CERT" > "$CERT_PATH"
+      # Tillåt både faktiska radbrytningar och \n-escape-sekvenser i .env-filen
+      printf '%b' "$TLS_CERT" > "$CERT_PATH"
     else
       echo "$TLS_CERT" | base64 -d > "$CERT_PATH"
     fi
     if echo "$TLS_KEY" | grep -q "BEGIN "; then
-      printf '%s' "$TLS_KEY" > "$KEY_PATH"
+      printf '%b' "$TLS_KEY" > "$KEY_PATH"
     else
       echo "$TLS_KEY" | base64 -d > "$KEY_PATH"
     fi


### PR DESCRIPTION
## Summary
- tolka \n-escape-sekvenser i TLS_CERT och TLS_KEY så att PEM-filerna skrivs korrekt

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d41759d2a4832da885e7729a15f93e