### PR TITLE
Update personnummer format to YYMMDDXXXX

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -196,15 +196,12 @@ def verify_password(hashed: str, password: str) -> bool:
 
 
 def normalize_personnummer(pnr: str) -> str:
-    """Normalize Swedish personal numbers to 12 digits."""
+    """Normalize Swedish personal numbers to the YYMMDDXXXX format."""
     logger.debug("Normalizing personnummer %s", pnr)
     digits = re.sub(r"\D", "", pnr)
-    if len(digits) == 10:
-        year = int(digits[:2])
-        current_year = datetime.now().year % 100
-        century = datetime.now().year // 100 - (1 if year > current_year else 0)
-        digits = f"{century:02d}{digits}"
-    if len(digits) != 12:
+    if len(digits) == 12:
+        digits = digits[2:]
+    if len(digits) != 10:
         logger.error("Invalid personnummer format: %s", pnr)
         raise ValueError("Ogiltigt personnummerformat.")
     logger.debug("Normalized personnummer to %s", digits)
@@ -529,7 +526,7 @@ def create_test_user() -> None:
     """Populate the database with a simple test user."""
     email = "test@example.com"
     username = "Test User"
-    personnummer = "199001011234"
+    personnummer = "9001011234"
     if not check_user_exists(email):
         admin_create_user(email, username, personnummer)
         pnr_hash = _hash_personnummer(personnummer)

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -59,8 +59,8 @@
   }
 
   function isValidPersonnummer(v) {
-    // Tillåt siffror och ett ev. bindestreck, 6–14 tecken (YYMMDDNNNN, YYYYMMDDNNNN, med/utan -)
-    return /^[0-9-]{6,14}$/.test(v);
+    // Tillåt sex siffror, valfritt bindestreck och fyra siffror (YYMMDD-XXXX eller YYMMDDXXXX)
+    return /^\d{6}-?\d{4}$/.test(v);
   }
 
   function validatePdf(file) {
@@ -95,7 +95,7 @@
       return;
     }
     if (!isValidPersonnummer(pnr)) {
-      showMessage('error', 'Ogiltigt personnummer. Tillåtna tecken: siffror och ev. bindestreck. Ex: 19900101-1234');
+      showMessage('error', 'Ogiltigt personnummer. Ange formatet ÅÅMMDDXXXX, t.ex. 900101-1234.');
       pnrInput.focus();
       return;
     }

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -14,9 +14,9 @@
         <div class="row">
             <div class="col">
                 <label for="personnummer">Personnummer</label>
-                <!-- Enkelt mönster: 6-12 siffror, tillåter format som YYMMDDNNNN eller YYYYMMDDNNNN -->
-                <input id="personnummer" name="personnummer" type="text" required pattern="[\\d\\-]{6,14}" placeholder="ÅÅMMDDNNNN" />
-                <small class="hint">Tillåtna tecken: siffror och bindestreck. Exempel: 19900101-1234</small>
+                <!-- Mönster: sex siffror, ev. bindestreck och fyra siffror (YYMMDD-XXXX eller YYMMDDXXXX) -->
+                <input id="personnummer" name="personnummer" type="text" required pattern="\\d{6}-?\\d{4}" placeholder="ÅÅMMDDXXXX" />
+                <small class="hint">Tillåtna tecken: siffror och bindestreck. Exempel: 900101-1234</small>
             </div>
 
             <div class="col">

--- a/templates/user_login.html
+++ b/templates/user_login.html
@@ -5,7 +5,7 @@
     {% if error %}<p class="error">{{ error }}</p>{% endif %}
     <form action="/login" method="POST">
         <label for="personnummer">Personnummer:</label>
-        <input type="text" id="personnummer" name="personnummer" required>
+        <input type="text" id="personnummer" name="personnummer" required placeholder="ÅÅMMDDXXXX">
         <label for="password">Lösenord:</label>
         <input type="password" id="password" name="password" required>
         <button type="submit">Logga in</button>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def user_db(tmp_path, monkeypatch):
                 username="Test",
                 email=functions.hash_value("test@example.com"),
                 password=functions.hash_password("secret"),
-                personnummer=functions.hash_value("199001011234"),
+                personnummer=functions.hash_value("9001011234"),
             )
         )
     return engine

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -41,9 +41,9 @@ valid_numbers = [f"199001{day:02d}-0000" for day in range(1, 11)]
 
 @pytest.mark.parametrize("pnr", valid_numbers)
 def test_normalize_personnummer_valid(pnr):
-    """Valid personal numbers should normalize to 12 digits."""
+    """Valid personal numbers should normalize to 10 digits."""
     normalized = normalize_personnummer(pnr)
-    assert len(normalized) == 12
+    assert len(normalized) == 10
     assert normalized.isdigit()
 
 

--- a/tests/test_admin_upload.py
+++ b/tests/test_admin_upload.py
@@ -19,7 +19,7 @@ def test_admin_upload_existing_user_only_saves_pdf(empty_db):
                 username="Existing",
                 email=functions.hash_value("exist@example.com"),
                 password=functions.hash_password("secret"),
-                personnummer=functions.hash_value("199001011234"),
+                personnummer=functions.hash_value("9001011234"),
             )
         )
 
@@ -36,7 +36,7 @@ def test_admin_upload_existing_user_only_saves_pdf(empty_db):
     assert response.status_code == 200
     assert response.get_json()["status"] == "success"
 
-    pnr_hash = functions.hash_value("199001011234")
+    pnr_hash = functions.hash_value("9001011234")
     with engine.connect() as conn:
         rows = list(
             conn.execute(
@@ -57,7 +57,7 @@ def test_admin_upload_existing_email(empty_db):
                 username="Existing",
                 email=functions.hash_value("exist@example.com"),
                 password=functions.hash_password("secret"),
-                personnummer=functions.hash_value("199001011234"),
+                personnummer=functions.hash_value("9001011234"),
             )
         )
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -4,8 +4,8 @@ import functions
 
 def test_dashboard_shows_only_user_pdfs(user_db):
     engine = user_db
-    own_hash = functions.hash_value("199001011234")
-    other_hash = functions.hash_value("200001011234")
+    own_hash = functions.hash_value("9001011234")
+    other_hash = functions.hash_value("0001011234")
 
     with engine.begin() as conn:
         conn.execute(
@@ -25,7 +25,7 @@ def test_dashboard_shows_only_user_pdfs(user_db):
         )
 
     with app.app.test_client() as client:
-        client.post("/login", data={"personnummer": "199001011234", "password": "secret"})
+        client.post("/login", data={"personnummer": "9001011234", "password": "secret"})
         response = client.get("/dashboard")
         assert b"own.pdf" in response.data
         assert b"other.pdf" not in response.data

--- a/tests/test_functions_additional.py
+++ b/tests/test_functions_additional.py
@@ -9,9 +9,9 @@ import functions  # noqa: E402
 
 
 def test_normalize_personnummer():
-    assert functions.normalize_personnummer("19900101-1234") == "199001011234"
-    assert functions.normalize_personnummer("199001011234") == "199001011234"
-    assert functions.normalize_personnummer("9001011234") == "199001011234"
+    assert functions.normalize_personnummer("19900101-1234") == "9001011234"
+    assert functions.normalize_personnummer("199001011234") == "9001011234"
+    assert functions.normalize_personnummer("9001011234") == "9001011234"
     with pytest.raises(ValueError):
         functions.normalize_personnummer("123")
 

--- a/tests/test_functions_extra.py
+++ b/tests/test_functions_extra.py
@@ -23,7 +23,7 @@ def test_hash_password_verify():
 def test_check_pending_user_and_hash(empty_db):
     functions.admin_create_user("e@example.com", "User", "19900101-1234")
     assert functions.check_pending_user("19900101-1234")
-    pnr_hash = functions.hash_value("199001011234")
+    pnr_hash = functions.hash_value("9001011234")
     assert functions.check_pending_user_hash(pnr_hash)
     assert not functions.check_pending_user("20000101-1234")
 
@@ -35,7 +35,7 @@ def test_admin_create_user_duplicate(empty_db):
                 username="Existing",
                 email=functions.hash_value("exist@example.com"),
                 password=functions.hash_password("secret"),
-                personnummer=functions.hash_value("199001011234"),
+                personnummer=functions.hash_value("9001011234"),
             )
         )
     assert not functions.admin_create_user("exist@example.com", "Existing", "19900101-1234")
@@ -48,7 +48,7 @@ def test_check_personnummer_password(empty_db):
                 username="Test",
                 email=functions.hash_value("test@example.com"),
                 password=functions.hash_password("secret"),
-                personnummer=functions.hash_value("199001011234"),
+                personnummer=functions.hash_value("9001011234"),
             )
         )
     assert functions.check_personnummer_password("19900101-1234", "secret")
@@ -62,7 +62,7 @@ def test_get_user_info(empty_db):
                 username="Info",
                 email=functions.hash_value("info@example.com"),
                 password=functions.hash_password("pass"),
-                personnummer=functions.hash_value("199001011234"),
+                personnummer=functions.hash_value("9001011234"),
             )
         )
     user = functions.get_user_info("19900101-1234")
@@ -72,7 +72,7 @@ def test_get_user_info(empty_db):
 
 
 def test_user_create_user_fails_if_exists(empty_db):
-    pnr_hash = functions.hash_value("199001011234")
+    pnr_hash = functions.hash_value("9001011234")
     with empty_db.begin() as conn:
         conn.execute(
             functions.users_table.insert().values(
@@ -101,7 +101,7 @@ def test_check_password_user_and_get_username(empty_db):
                 username=username,
                 email=functions.hash_value(email),
                 password=functions.hash_password(password),
-                personnummer=functions.hash_value("199001011234"),
+                personnummer=functions.hash_value("9001011234"),
             )
         )
 

--- a/tests/test_functions_more.py
+++ b/tests/test_functions_more.py
@@ -42,6 +42,6 @@ def test_verify_certificate_not_found(empty_db):
 
 
 def test_user_create_user_no_pending(empty_db):
-    pnr_hash = functions.hash_value("199001011234")
+    pnr_hash = functions.hash_value("9001011234")
     assert not functions.user_create_user("pass", pnr_hash)
 

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -2,7 +2,7 @@ import pytest
 import app
 
 
-@pytest.mark.parametrize("pnr_input", ["199001011234", "19900101-1234", "900101-1234"])
+@pytest.mark.parametrize("pnr_input", ["9001011234", "900101-1234", "199001011234"])
 def test_login_success(user_db, pnr_input):
     with app.app.test_client() as client:
         response = client.post("/login", data={"personnummer": pnr_input, "password": "secret"})
@@ -11,5 +11,5 @@ def test_login_success(user_db, pnr_input):
 
 def test_login_failure(user_db):
     with app.app.test_client() as client:
-        response = client.post("/login", data={"personnummer": "199001011234", "password": "wrong"})
+        response = client.post("/login", data={"personnummer": "9001011234", "password": "wrong"})
         assert response.status_code == 401

--- a/tests/test_logout.py
+++ b/tests/test_logout.py
@@ -3,7 +3,7 @@ import app
 
 def test_logout_clears_user_session(user_db):
     with app.app.test_client() as client:
-        client.post("/login", data={"personnummer": "199001011234", "password": "secret"})
+        client.post("/login", data={"personnummer": "9001011234", "password": "secret"})
         with client.session_transaction() as sess:
             assert sess.get("user_logged_in")
         client.get("/logout")

--- a/tests/test_normalize_personnummer.py
+++ b/tests/test_normalize_personnummer.py
@@ -3,8 +3,8 @@ import functions
 
 
 def test_normalize_personnummer_valid():
-    assert functions.normalize_personnummer(" 19900101-1234 ") == "199001011234"
-    assert functions.normalize_personnummer("900101-1234") == "199001011234"
+    assert functions.normalize_personnummer(" 19900101-1234 ") == "9001011234"
+    assert functions.normalize_personnummer("900101-1234") == "9001011234"
 
 
 def test_normalize_personnummer_invalid():

--- a/tests/test_pdf_storage.py
+++ b/tests/test_pdf_storage.py
@@ -19,7 +19,7 @@ def test_store_pdf_blob_returns_unique_ids(empty_db):
 
     _ = empty_db  # ensure database is initialized
 
-    pnr_hash = _personnummer_hash("199001011234")
+    pnr_hash = _personnummer_hash("9001011234")
     first_id = functions.store_pdf_blob(pnr_hash, "first.pdf", b"%PDF-1.4 first")
     second_id = functions.store_pdf_blob(pnr_hash, "second.pdf", b"%PDF-1.4 second")
 
@@ -34,7 +34,7 @@ def test_get_pdf_metadata_returns_expected_information(empty_db):
 
     _ = empty_db
 
-    pnr_hash = _personnummer_hash("199001011234")
+    pnr_hash = _personnummer_hash("9001011234")
     pdf_id = functions.store_pdf_blob(pnr_hash, "metadata.pdf", b"%PDF-1.4 metadata")
 
     metadata = functions.get_pdf_metadata(pnr_hash, pdf_id)
@@ -50,8 +50,8 @@ def test_get_pdf_metadata_handles_missing_entries(empty_db):
 
     _ = empty_db
 
-    primary_hash = _personnummer_hash("199001011234")
-    other_hash = _personnummer_hash("199002024567")
+    primary_hash = _personnummer_hash("9001011234")
+    other_hash = _personnummer_hash("9002024567")
     pdf_id = functions.store_pdf_blob(primary_hash, "missing.pdf", b"%PDF-1.4 missing")
 
     assert functions.get_pdf_metadata(other_hash, pdf_id) is None

--- a/tests/test_save_pdf.py
+++ b/tests/test_save_pdf.py
@@ -24,11 +24,11 @@ def _file_storage(data: bytes, filename: str, mimetype: str = "application/pdf")
 
 
 def test_save_pdf_stores_in_database(empty_db):
-    pdf = _file_storage(b"%PDF-1.4 test", "199001011234_resume.pdf")
-    result = save_pdf_for_user("199001011234", pdf)
+    pdf = _file_storage(b"%PDF-1.4 test", "9001011234_resume.pdf")
+    result = save_pdf_for_user("9001011234", pdf)
 
     assert "id" in result and "filename" in result
-    assert "199001011234" not in result["filename"]
+    assert "9001011234" not in result["filename"]
 
     with functions.get_engine().connect() as conn:
         row = conn.execute(
@@ -38,14 +38,14 @@ def test_save_pdf_stores_in_database(empty_db):
         ).first()
     assert row is not None
     assert row.filename == result["filename"]
-    assert row.personnummer == functions.hash_value("199001011234")
+    assert row.personnummer == functions.hash_value("9001011234")
     assert row.content.startswith(b"%PDF-")
 
 
 def test_save_pdf_rejects_invalid_files(empty_db):
     not_pdf = _file_storage(b"not pdf", "doc.pdf")
     with pytest.raises(ValueError):
-        save_pdf_for_user("199001011234", not_pdf)
+        save_pdf_for_user("9001011234", not_pdf)
     wrong_mime = _file_storage(b"%PDF-1.4 test", "doc.pdf", mimetype="text/plain")
     with pytest.raises(ValueError):
-        save_pdf_for_user("199001011234", wrong_mime)
+        save_pdf_for_user("9001011234", wrong_mime)

--- a/tests/test_user_create.py
+++ b/tests/test_user_create.py
@@ -2,7 +2,7 @@ import functions
 
 
 def test_user_create_hashes_password(empty_db):
-    pnr_hash = functions.hash_value("199001011234")
+    pnr_hash = functions.hash_value("9001011234")
     with empty_db.begin() as conn:
         conn.execute(
             functions.pending_users_table.insert().values(

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -14,7 +14,7 @@ def test_check_user_exists(empty_db):
                 username="Exists",
                 email=functions.hash_value(email),
                 password=functions.hash_password("pass"),
-                personnummer=functions.hash_value("199001011234"),
+                personnummer=functions.hash_value("9001011234"),
             )
         )
 

--- a/tests/test_user_queries.py
+++ b/tests/test_user_queries.py
@@ -16,11 +16,12 @@ def test_verify_certificate_existing_user(empty_db):
                 username="Test",
                 email=functions.hash_value("user@example.com"),
                 password=functions.hash_password("secret"),
-                personnummer=functions.hash_value("199001011234"),
+                personnummer=functions.hash_value("9001011234"),
             )
         )
     functions.verify_certificate.cache_clear()
     assert functions.verify_certificate("199001011234")
+    assert functions.verify_certificate("9001011234")
 
 
 def test_check_user_exists(empty_db):
@@ -31,7 +32,7 @@ def test_check_user_exists(empty_db):
                 username="Tester",
                 email=functions.hash_value(email),
                 password=functions.hash_password("pass"),
-                personnummer=functions.hash_value("199001011234"),
+                personnummer=functions.hash_value("9001011234"),
             )
         )
     assert functions.check_user_exists(email)


### PR DESCRIPTION
## Summary
- update personnummer normalization to emit YYMMDDXXXX and accept optional 12-digit input
- align admin UI validation and hints with the new format
- adjust tests and fixtures to reflect the 10-digit personnummer convention

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d42e5f70a0832d8f57483a5cbc2c7d