### PR TITLE
Adjust activation email logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -188,8 +188,9 @@ def send_creation_email(to_email: str, link: str) -> None:
                 logger.error("SMTP server refused recipients: %s", refused)
                 raise RuntimeError("E-postservern accepterade inte mottagaren.")
 
-        logger.info(
-            "Skickade aktiveringslänk till %s (Message-ID %s)",
+        logger.info("Skickade aktiveringslänk till %s", normalized_email)
+        logger.debug(
+            "Meddelande-ID för utskick till %s: %s",
             normalized_email,
             msg["Message-ID"],
         )


### PR DESCRIPTION
## Summary
- stop including the SMTP Message-ID in the info-level activation email log entry
- add a debug log that records the Message-ID for traceability

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d431d24144832db1f4fc286e3dd239