### PR TITLE
Fix duplicate log entries by centralizing logger configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,6 +34,7 @@ from flask import (
 from werkzeug.utils import secure_filename
 
 from config_loader import load_environment
+from logging_utils import configure_module_logger
 
 
 load_environment()
@@ -42,9 +43,8 @@ import functions
 
 ALLOWED_MIMES = {'application/pdf'}
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)  
-logger.propagate = True  
+logger = configure_module_logger(__name__)
+logger.setLevel(logging.INFO)
 # functions.create_test_user()  # Skapa en testanvändare vid start
 def _enable_debug_mode(app: Flask) -> None:
     """Aktivera extra loggning och ev. testdata i debug-läge."""

--- a/functions.py
+++ b/functions.py
@@ -33,10 +33,10 @@ from sqlalchemy.pool import StaticPool
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from config_loader import load_environment
+from logging_utils import configure_module_logger
 
-logger = logging.getLogger(__name__)
+logger = configure_module_logger(__name__)
 logger.setLevel(logging.DEBUG)  # or INFO in production
-logger.propagate = True
 
 load_environment()
 

--- a/logging_utils.py
+++ b/logging_utils.py
@@ -1,0 +1,48 @@
+"""Helpers for consistent logging configuration across the project."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+
+def configure_module_logger(name: str) -> logging.Logger:
+    """Return a module logger configured to avoid duplicate log output.
+
+    The application runs under different WSGI servers depending on the
+    environment (development Flask server, gunicorn, tests, etc.).  Several of
+    these set up their own handlers on the root logger which can result in the
+    same log record being emitted multiple times when module loggers propagate
+    to the root.
+
+    This helper reuses the root handlers but disables propagation on the module
+    logger so that each log record is handled exactly once, regardless of how
+    many handlers the root logger has.  If no root handlers exist we create a
+    simple ``StreamHandler`` so logs are still visible during local execution.
+    """
+
+    logger = logging.getLogger(name)
+    if getattr(logger, "_jk_configured", False):
+        return logger
+
+    root_logger = logging.getLogger()
+    handlers: Iterable[logging.Handler]
+    if root_logger.handlers:
+        handlers = root_logger.handlers
+    else:
+        handler = logging.StreamHandler()
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+        )
+        root_logger.addHandler(handler)
+        handlers = (handler,)
+
+    for handler in handlers:
+        logger.addHandler(handler)
+
+    if logger.level == logging.NOTSET:
+        logger.setLevel(root_logger.level or logging.INFO)
+
+    logger.propagate = False
+    setattr(logger, "_jk_configured", True)
+    return logger


### PR DESCRIPTION
## Summary
- add a shared logging helper that reuses root handlers while disabling propagation to prevent duplicate log output
- update the application and utility modules to use the shared helper for consistent logger configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4313058f4832d9d87d8b9f51e1338