### PR TITLE
Tillåt personnummer med sekel i adminformuläret

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -59,8 +59,8 @@
   }
 
   function isValidPersonnummer(v) {
-    // Tillåt sex siffror, valfritt bindestreck och fyra siffror (YYMMDD-XXXX eller YYMMDDXXXX)
-    return /^\d{6}-?\d{4}$/.test(v);
+    // Tillåt sex eller åtta siffror, valfritt bindestreck och fyra siffror (ÅÅMMDDXXXX eller ÅÅÅÅMMDDXXXX)
+    return /^(?:\d{6}|\d{8})-?\d{4}$/.test(v);
   }
 
   function validatePdf(file) {
@@ -95,7 +95,10 @@
       return;
     }
     if (!isValidPersonnummer(pnr)) {
-      showMessage('error', 'Ogiltigt personnummer. Ange formatet ÅÅMMDDXXXX, t.ex. 900101-1234.');
+      showMessage(
+        'error',
+        'Ogiltigt personnummer. Ange ÅÅMMDDXXXX eller ÅÅÅÅMMDDXXXX, t.ex. 900101-1234 eller 19900101-1234.'
+      );
       pnrInput.focus();
       return;
     }

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -14,9 +14,9 @@
         <div class="row">
             <div class="col">
                 <label for="personnummer">Personnummer</label>
-                <!-- Mönster: sex siffror, ev. bindestreck och fyra siffror (YYMMDD-XXXX eller YYMMDDXXXX) -->
-                <input id="personnummer" name="personnummer" type="text" required pattern="\\d{6}-?\\d{4}" placeholder="ÅÅMMDDXXXX" />
-                <small class="hint">Tillåtna tecken: siffror och bindestreck. Exempel: 900101-1234</small>
+                <!-- Mönster: sex eller åtta siffror, valfritt bindestreck och fyra siffror -->
+                <input id="personnummer" name="personnummer" type="text" required pattern="(?:\\d{6}|\\d{8})-?\\d{4}" placeholder="ÅÅMMDDXXXX" />
+                <small class="hint">Tillåtna format: ÅÅMMDDXXXX, ÅÅÅÅMMDDXXXX, med eller utan bindestreck.</small>
             </div>
 
             <div class="col">


### PR DESCRIPTION
## Summary
- uppdatera adminformulärets personnummerfält för att acceptera både 10- och 12-siffriga format
- synkronisera klientvalideringen och felmeddelandet med de nya formaten

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4358ad048832d89bf79c449653ca5