### PR TITLE
Lägg till kategoristöd för PDF:er

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -36,3 +36,44 @@
 .pdf-list li a:hover {
     text-decoration: underline;
 }
+
+.pdf-category {
+    margin: 8px 0 0;
+    color: #555;
+    font-size: 0.9rem;
+}
+
+.category-filter {
+    margin-bottom: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.category-filter label {
+    font-weight: 600;
+}
+
+.filter-controls {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.category-filter select {
+    padding: 6px 10px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    min-width: 180px;
+}
+
+.reset-filter {
+    color: #555;
+    text-decoration: none;
+    font-size: 0.9rem;
+}
+
+.reset-filter:hover {
+    text-decoration: underline;
+}

--- a/static/css/pdf_viewer.css
+++ b/static/css/pdf_viewer.css
@@ -7,6 +7,12 @@
     overflow: hidden;
 }
 
+.pdf-category {
+    margin: 0 0 16px;
+    color: #555;
+    font-size: 0.95rem;
+}
+
 .pdf-container iframe {
     width: 100%;
     height: 100%;

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -13,6 +13,7 @@
   const usernameInput = document.getElementById('username');
   const pnrInput = document.getElementById('personnummer');
   const pdfInput = document.getElementById('pdf');
+  const categoryInput = document.getElementById('category');
 
   // --- Konstanter (synka gärna med servern) ---
   const MAX_MB = 100; // matchar app.config['MAX_CONTENT_LENGTH']
@@ -83,6 +84,7 @@
     const username = usernameInput.value.trim();
     const pnr = pnrInput.value.trim();
     const files = Array.from(pdfInput.files);
+    const category = categoryInput.value.trim();
 
     if (!isValidEmail(email)) {
       showMessage('error', 'Ogiltig e-postadress.');
@@ -107,6 +109,11 @@
       pdfInput.focus();
       return;
     }
+    if (category.length > 100) {
+      showMessage('error', 'Kategorin får vara högst 100 tecken.');
+      categoryInput.focus();
+      return;
+    }
     const totalSize = files.reduce((sum, f) => sum + f.size, 0);
     if (totalSize > MAX_BYTES) {
       showMessage('error', `Filerna är för stora (max ${MAX_MB} MB totalt).`);
@@ -127,6 +134,7 @@
     fd.append('email', email);
     fd.append('username', username);
     fd.append('personnummer', pnr);
+    fd.append('category', category);
     for (const file of files) {
       fd.append('pdf', file);
     }
@@ -175,7 +183,7 @@
   });
 
   // --- UX: rensa status när användaren ändrar något ---
-  [emailInput, usernameInput, pnrInput, pdfInput].forEach((el) => {
+  [emailInput, usernameInput, pnrInput, pdfInput, categoryInput].forEach((el) => {
     el.addEventListener('input', () => hideMessage());
     el.addEventListener('change', () => hideMessage());
   });

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -26,6 +26,10 @@
             </div>
         </div>
 
+        <label for="category">Kategori</label>
+        <input id="category" name="category" type="text" placeholder="Exempel: Kurs, Intyg, Rapport" />
+        <small class="hint">Används för att hjälpa användaren hitta rätt dokument. Lämna tomt för "Övrigt".</small>
+
         <button id="submitBtn" type="submit">Skapa användare</button>
 
         <div id="progressContainer" class="progress-container" style="display:none">

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -6,6 +6,23 @@
 {% block content %}
 <section class="dashboard">
     <h1>Dina PDF:er</h1>
+    {% if categories %}
+    <form class="category-filter" method="get">
+        <label for="categorySelect">Filtrera på kategori</label>
+        <div class="filter-controls">
+            <select id="categorySelect" name="kategori" onchange="this.form.submit()">
+                <option value="" {% if not selected_category %}selected{% endif %}>Alla kategorier</option>
+                {% for category in categories %}
+                <option value="{{ category }}" {% if category == selected_category %}selected{% endif %}>{{ category }}</option>
+                {% endfor %}
+            </select>
+            {% if selected_category %}
+            <a class="reset-filter" href="{{ url_for('dashboard') }}">Rensa filter</a>
+            {% endif %}
+        </div>
+    </form>
+    {% endif %}
+
     {% if pdfs %}
     <ul class="pdf-list">
         {% for pdf in pdfs %}
@@ -13,6 +30,7 @@
             <a href="{{ url_for('view_pdf', pdf_id=pdf.id) }}">
                 {{ pdf.filename }}
             </a>
+            <p class="pdf-category">Kategori: {{ pdf.category }}</p>
         </li>
         {% endfor %}
     </ul>

--- a/templates/view_pdf.html
+++ b/templates/view_pdf.html
@@ -5,6 +5,7 @@
 {% endblock %}
 {% block content %}
 <h1>{{ filename }}</h1>
+<p class="pdf-category">Kategori: {{ category }}</p>
 <div class="pdf-container">
     <iframe src="{{ pdf_url }}" title="{{ filename }}" frameborder="0"></iframe>
 </div>

--- a/tests/test_admin_upload.py
+++ b/tests/test_admin_upload.py
@@ -28,6 +28,7 @@ def test_admin_upload_existing_user_only_saves_pdf(empty_db):
         "email": "exist@example.com",
         "username": "Existing",
         "personnummer": "19900101-1234",
+        "category": "Intyg",
         "pdf": (io.BytesIO(pdf_bytes), "doc.pdf"),
     }
 
@@ -47,6 +48,7 @@ def test_admin_upload_existing_user_only_saves_pdf(empty_db):
         )
     assert len(rows) == 1
     assert rows[0].content == pdf_bytes
+    assert rows[0].category == "Intyg"
 
 
 def test_admin_upload_existing_email(empty_db):
@@ -66,6 +68,7 @@ def test_admin_upload_existing_email(empty_db):
         "email": "exist@example.com",
         "username": "Existing",
         "personnummer": "20000101-9999",
+        "category": "Kurs",
         "pdf": (io.BytesIO(pdf_bytes), "doc.pdf"),
     }
 
@@ -85,6 +88,7 @@ def test_admin_upload_existing_email(empty_db):
         )
     assert len(rows) == 1
     assert rows[0].content == pdf_bytes
+    assert rows[0].category == "Kurs"
 
 
 def test_admin_upload_pending_user(empty_db):
@@ -100,6 +104,7 @@ def test_admin_upload_pending_user(empty_db):
         "email": email,
         "username": username,
         "personnummer": personnummer,
+        "category": "Rapport",
         "pdf": (io.BytesIO(pdf_bytes), "doc.pdf"),
     }
 
@@ -125,3 +130,4 @@ def test_admin_upload_pending_user(empty_db):
         )
     assert len(rows) == 1
     assert rows[0].content == pdf_bytes
+    assert rows[0].category == "Rapport"

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -14,11 +14,13 @@ def test_dashboard_shows_only_user_pdfs(user_db):
                 {
                     "personnummer": own_hash,
                     "filename": "own.pdf",
+                    "category": "Utbildning",
                     "content": b"%PDF-1.4 own",
                 },
                 {
                     "personnummer": other_hash,
                     "filename": "other.pdf",
+                    "category": "Annat",
                     "content": b"%PDF-1.4 other",
                 },
             ],
@@ -29,3 +31,35 @@ def test_dashboard_shows_only_user_pdfs(user_db):
         response = client.get("/dashboard")
         assert b"own.pdf" in response.data
         assert b"other.pdf" not in response.data
+        assert "Kategori: Utbildning".encode() in response.data
+
+
+def test_dashboard_category_filter(user_db):
+    engine = user_db
+    pnr_hash = functions.hash_value("9001011234")
+
+    with engine.begin() as conn:
+        conn.execute(
+            functions.user_pdfs_table.insert(),
+            [
+                {
+                    "personnummer": pnr_hash,
+                    "filename": "first.pdf",
+                    "category": "Kurs",
+                    "content": b"%PDF-1.4 first",
+                },
+                {
+                    "personnummer": pnr_hash,
+                    "filename": "second.pdf",
+                    "category": "Intyg",
+                    "content": b"%PDF-1.4 second",
+                },
+            ],
+        )
+
+    with app.app.test_client() as client:
+        client.post("/login", data={"personnummer": "9001011234", "password": "secret"})
+        response = client.get("/dashboard", query_string={"kategori": "Intyg"})
+        assert b"second.pdf" in response.data
+        assert b"first.pdf" not in response.data
+        assert b'value="Intyg" selected' in response.data

--- a/tests/test_pdf_storage.py
+++ b/tests/test_pdf_storage.py
@@ -20,8 +20,12 @@ def test_store_pdf_blob_returns_unique_ids(empty_db):
     _ = empty_db  # ensure database is initialized
 
     pnr_hash = _personnummer_hash("9001011234")
-    first_id = functions.store_pdf_blob(pnr_hash, "first.pdf", b"%PDF-1.4 first")
-    second_id = functions.store_pdf_blob(pnr_hash, "second.pdf", b"%PDF-1.4 second")
+    first_id = functions.store_pdf_blob(
+        pnr_hash, "first.pdf", b"%PDF-1.4 first", "Intyg"
+    )
+    second_id = functions.store_pdf_blob(
+        pnr_hash, "second.pdf", b"%PDF-1.4 second", "Kurs"
+    )
 
     assert isinstance(first_id, int)
     assert isinstance(second_id, int)
@@ -35,7 +39,9 @@ def test_get_pdf_metadata_returns_expected_information(empty_db):
     _ = empty_db
 
     pnr_hash = _personnummer_hash("9001011234")
-    pdf_id = functions.store_pdf_blob(pnr_hash, "metadata.pdf", b"%PDF-1.4 metadata")
+    pdf_id = functions.store_pdf_blob(
+        pnr_hash, "metadata.pdf", b"%PDF-1.4 metadata", "Rapport"
+    )
 
     metadata = functions.get_pdf_metadata(pnr_hash, pdf_id)
 
@@ -43,6 +49,7 @@ def test_get_pdf_metadata_returns_expected_information(empty_db):
     assert metadata["id"] == pdf_id
     assert metadata["filename"] == "metadata.pdf"
     assert isinstance(metadata["uploaded_at"], datetime)
+    assert metadata["category"] == "Rapport"
 
 
 def test_get_pdf_metadata_handles_missing_entries(empty_db):
@@ -52,7 +59,9 @@ def test_get_pdf_metadata_handles_missing_entries(empty_db):
 
     primary_hash = _personnummer_hash("9001011234")
     other_hash = _personnummer_hash("9002024567")
-    pdf_id = functions.store_pdf_blob(primary_hash, "missing.pdf", b"%PDF-1.4 missing")
+    pdf_id = functions.store_pdf_blob(
+        primary_hash, "missing.pdf", b"%PDF-1.4 missing", "Rapport"
+    )
 
     assert functions.get_pdf_metadata(other_hash, pdf_id) is None
     assert functions.get_pdf_metadata(primary_hash, pdf_id + 100) is None

--- a/tests/test_save_pdf.py
+++ b/tests/test_save_pdf.py
@@ -25,10 +25,11 @@ def _file_storage(data: bytes, filename: str, mimetype: str = "application/pdf")
 
 def test_save_pdf_stores_in_database(empty_db):
     pdf = _file_storage(b"%PDF-1.4 test", "9001011234_resume.pdf")
-    result = save_pdf_for_user("9001011234", pdf)
+    result = save_pdf_for_user("9001011234", pdf, "Intyg")
 
     assert "id" in result and "filename" in result
     assert "9001011234" not in result["filename"]
+    assert result["category"] == "Intyg"
 
     with functions.get_engine().connect() as conn:
         row = conn.execute(
@@ -40,12 +41,13 @@ def test_save_pdf_stores_in_database(empty_db):
     assert row.filename == result["filename"]
     assert row.personnummer == functions.hash_value("9001011234")
     assert row.content.startswith(b"%PDF-")
+    assert row.category == "Intyg"
 
 
 def test_save_pdf_rejects_invalid_files(empty_db):
     not_pdf = _file_storage(b"not pdf", "doc.pdf")
     with pytest.raises(ValueError):
-        save_pdf_for_user("9001011234", not_pdf)
+        save_pdf_for_user("9001011234", not_pdf, "Intyg")
     wrong_mime = _file_storage(b"%PDF-1.4 test", "doc.pdf", mimetype="text/plain")
     with pytest.raises(ValueError):
-        save_pdf_for_user("9001011234", wrong_mime)
+        save_pdf_for_user("9001011234", wrong_mime, "Intyg")

--- a/tests/test_save_pdf_for_user.py
+++ b/tests/test_save_pdf_for_user.py
@@ -14,8 +14,9 @@ def test_save_pdf_for_user(empty_db):
         content_type="application/pdf",
     )
 
-    result = app.save_pdf_for_user("19900101-1234", file_storage)
+    result = app.save_pdf_for_user("19900101-1234", file_storage, "Utbildning")
     assert result["id"] > 0
+    assert result["category"] == "Utbildning"
 
     with functions.get_engine().connect() as conn:
         row = conn.execute(
@@ -26,3 +27,4 @@ def test_save_pdf_for_user(empty_db):
     assert row is not None
     assert row.content == pdf_bytes
     assert row.filename == result["filename"]
+    assert row.category == "Utbildning"


### PR DESCRIPTION
## Sammanfattning
- låter administratören ange kategori vid uppladdning och sparar den i databasen
- visar kategorier i användarens vy och möjliggör filtrering på dashboarden
- uppdaterar klientlogik och tester för den nya funktionaliteten

## Testning
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d438dd14ac832da5594d5f56af82d3