### PR TITLE
Visa kategorilista utan kryssrutor på dashboard

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -37,32 +37,34 @@
     text-decoration: underline;
 }
 
-.category-filter {
+.category-list {
     margin-bottom: 20px;
-}
-
-.category-filter fieldset {
     border: 1px solid #ddd;
     border-radius: 6px;
     padding: 12px 16px;
     background-color: #fdfdfd;
 }
 
-.category-filter legend {
-    font-weight: 600;
-    margin-bottom: 8px;
+.category-list h2 {
+    margin-top: 0;
+    margin-bottom: 12px;
+    font-size: 1.1rem;
 }
 
-.category-options {
+.category-list ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
     display: flex;
     flex-wrap: wrap;
     gap: 12px;
 }
 
-.checkbox-option {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
+.category-list li {
+    background-color: #ffffff;
+    border: 1px solid #d5d5d5;
+    border-radius: 16px;
+    padding: 6px 14px;
     font-size: 0.95rem;
 }
 
@@ -73,9 +75,3 @@
     font-size: 0.95rem;
 }
 
-.no-results {
-    margin-top: 16px;
-    color: #b00020;
-    font-weight: 600;
-    display: none;
-}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -7,19 +7,14 @@
 <section class="dashboard">
     <h1>Dina PDF:er</h1>
     {% if course_categories %}
-    <form class="category-filter" id="categoryFilter">
-        <fieldset>
-            <legend>Filtrera efter kurskategori</legend>
-            <div class="category-options">
-                {% for slug, label in course_categories %}
-                <label class="checkbox-option">
-                    <input type="checkbox" value="{{ slug }}" data-category-filter />
-                    <span>{{ label }}</span>
-                </label>
-                {% endfor %}
-            </div>
-        </fieldset>
-    </form>
+    <section class="category-list" aria-label="Tillgängliga kurskategorier">
+        <h2>Kurskategorier</h2>
+        <ul>
+            {% for slug, label in course_categories %}
+            <li>{{ label }}</li>
+            {% endfor %}
+        </ul>
+    </section>
     {% endif %}
 
     {% if pdfs %}
@@ -40,10 +35,8 @@
         </li>
         {% endfor %}
     </ul>
-    <p id="noFilteredResults" class="no-results">Inga PDF:er matchar de valda kategorierna.</p>
     {% else %}
     <p>Inga PDF:er uppladdade.</p>
     {% endif %}
 </section>
-<script src="{{ url_for('static', filename='js/dashboard.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- ersätt kategori-filtret på användaröversikten med en enkel lista som endast visar titlarna
- uppdatera dashboard-stilarna för att formatera den nya kategorilistan

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4418f8424832db71fca82db328d1c