### PR TITLE
Group dashboard certificates by category

### DIFF
--- a/app.py
+++ b/app.py
@@ -338,9 +338,53 @@ def dashboard():
     pdfs = functions.get_user_pdfs(pnr_hash)
     for pdf in pdfs:
         pdf["category_labels"] = labels_for_slugs(pdf.get("categories", []))
+    grouped_pdfs = []
+    groups_by_slug = {}
+    for slug, label in COURSE_CATEGORIES:
+        group = {"slug": slug, "label": label, "pdfs": []}
+        grouped_pdfs.append(group)
+        groups_by_slug[slug] = group
+    uncategorized_group = {
+        "slug": "okategoriserade",
+        "label": "Okategoriserade intyg",
+        "pdfs": [],
+    }
+    for pdf in pdfs:
+        categories = pdf.get("categories") or []
+        matched = False
+        for slug in categories:
+            group = groups_by_slug.get(slug)
+            if group is not None:
+                group["pdfs"].append(pdf)
+                matched = True
+        if not matched:
+            uncategorized_group["pdfs"].append(pdf)
+    visible_groups = [group for group in grouped_pdfs if group["pdfs"]]
+    if uncategorized_group["pdfs"]:
+        visible_groups.append(uncategorized_group)
+    category_summary = [
+        {
+            "slug": slug,
+            "label": label,
+            "count": len(groups_by_slug[slug]["pdfs"]),
+        }
+        for slug, label in COURSE_CATEGORIES
+    ]
+    if uncategorized_group["pdfs"]:
+        category_summary.append(
+            {
+                "slug": uncategorized_group["slug"],
+                "label": uncategorized_group["label"],
+                "count": len(uncategorized_group["pdfs"]),
+            }
+        )
     logger.debug("Dashboard for %s shows %d pdfs", pnr_hash, len(pdfs))
     return render_template(
-        'dashboard.html', pdfs=pdfs, course_categories=COURSE_CATEGORIES
+        'dashboard.html',
+        pdfs=pdfs,
+        course_categories=COURSE_CATEGORIES,
+        category_summary=category_summary,
+        grouped_pdfs=visible_groups,
     )
 
 

--- a/app.py
+++ b/app.py
@@ -315,7 +315,11 @@ def login():
         logger.debug("Login attempt for %s", personnummer)
         if functions.check_personnummer_password(personnummer, password):
             session['user_logged_in'] = True
-            session['personnummer'] = functions.hash_value(personnummer)
+            personnummer_hash = functions.hash_value(personnummer)
+            session['personnummer'] = personnummer_hash
+            session['username'] = functions.get_username_by_personnummer_hash(
+                personnummer_hash
+            )
             logger.info("User %s logged in", personnummer)
             return redirect('/dashboard')
         else:
@@ -335,6 +339,11 @@ def dashboard():
         logger.debug("Unauthenticated access to dashboard")
         return redirect('/login')
     pnr_hash = session.get('personnummer')
+    user_name = session.get('username')
+    if not user_name and pnr_hash:
+        user_name = functions.get_username_by_personnummer_hash(pnr_hash)
+        if user_name:
+            session['username'] = user_name
     pdfs = functions.get_user_pdfs(pnr_hash)
     for pdf in pdfs:
         pdf["category_labels"] = labels_for_slugs(pdf.get("categories", []))
@@ -385,6 +394,7 @@ def dashboard():
         course_categories=COURSE_CATEGORIES,
         category_summary=category_summary,
         grouped_pdfs=visible_groups,
+        user_name=user_name,
     )
 
 

--- a/functions.py
+++ b/functions.py
@@ -438,6 +438,17 @@ def get_user_info(personnummer: str):
     return row
 
 
+def get_username_by_personnummer_hash(personnummer_hash: str) -> Optional[str]:
+    """Return the username tied to ``personnummer_hash`` if it exists."""
+    with get_engine().connect() as conn:
+        row = conn.execute(
+            select(users_table.c.username).where(
+                users_table.c.personnummer == personnummer_hash
+            )
+        ).first()
+    return row.username if row else None
+
+
 def _serialize_categories(categories: Sequence[str] | None) -> str:
     if not categories:
         return ""

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -66,6 +66,54 @@
     border-radius: 16px;
     padding: 6px 14px;
     font-size: 0.95rem;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.category-label {
+    font-weight: 600;
+}
+
+.category-count-badge {
+    background-color: #eef3ff;
+    border-radius: 12px;
+    padding: 2px 10px;
+    font-size: 0.85rem;
+    color: #1a4bbf;
+}
+
+.category-groups {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.category-group {
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    padding: 16px;
+    background-color: #ffffff;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.category-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 12px;
+    gap: 8px;
+}
+
+.category-header h3 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.category-count {
+    margin: 0;
+    font-size: 0.95rem;
+    color: #444;
 }
 
 .pdf-meta {
@@ -73,5 +121,9 @@
     margin-top: 8px;
     color: #555;
     font-size: 0.95rem;
+}
+
+.category-group .pdf-list {
+    margin: 0;
 }
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -6,35 +6,48 @@
 {% block content %}
 <section class="dashboard">
     <h1>Dina PDF:er</h1>
-    {% if course_categories %}
+    {% if category_summary %}
     <section class="category-list" aria-label="Tillgängliga kurskategorier">
         <h2>Kurskategorier</h2>
         <ul>
-            {% for slug, label in course_categories %}
-            <li>{{ label }}</li>
+            {% for category in category_summary %}
+            <li>
+                <span class="category-label">{{ category.label }}</span>
+                <span class="category-count-badge">{{ category.count }} intyg</span>
+            </li>
             {% endfor %}
         </ul>
     </section>
     {% endif %}
 
-    {% if pdfs %}
-    <ul class="pdf-list">
-        {% for pdf in pdfs %}
-        <li data-pdf-categories="{{ pdf.categories | join(',') }}">
-            <a href="{{ url_for('download_pdf', pdf_id=pdf.id) }}" download>
-                {{ pdf.filename }}
-            </a>
-            <span class="pdf-meta">
-                <strong>Kategori:</strong>
-                {% if pdf.category_labels %}
-                    {{ pdf.category_labels | join(', ') }}
-                {% else %}
-                    Inte angiven
-                {% endif %}
-            </span>
-        </li>
+    {% if grouped_pdfs %}
+    <section class="category-groups" aria-label="Intyg sorterade efter kategori">
+        {% for group in grouped_pdfs %}
+        <article class="category-group">
+            <header class="category-header">
+                <h3>{{ group.label }}</h3>
+                <p class="category-count">{{ group.pdfs | length }} intyg</p>
+            </header>
+            <ul class="pdf-list">
+                {% for pdf in group.pdfs %}
+                <li data-pdf-categories="{{ pdf.categories | join(',') }}">
+                    <a href="{{ url_for('download_pdf', pdf_id=pdf.id) }}" download>
+                        {{ pdf.filename }}
+                    </a>
+                    <span class="pdf-meta">
+                        <strong>Kategorier:</strong>
+                        {% if pdf.category_labels %}
+                            {{ pdf.category_labels | join(', ') }}
+                        {% else %}
+                            Inte angiven
+                        {% endif %}
+                    </span>
+                </li>
+                {% endfor %}
+            </ul>
+        </article>
         {% endfor %}
-    </ul>
+    </section>
     {% else %}
     <p>Inga PDF:er uppladdade.</p>
     {% endif %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -5,7 +5,13 @@
 {% endblock %}
 {% block content %}
 <section class="dashboard">
-    <h1>Dina PDF:er</h1>
+    <h1>
+        {% if user_name %}
+            Hej {{ user_name }}! Här är dina intyg.
+        {% else %}
+            Hej! Här är dina intyg.
+        {% endif %}
+    </h1>
     {% if category_summary %}
     <section class="category-list" aria-label="Tillgängliga kurskategorier">
         <h2>Kurskategorier</h2>

--- a/tests/test_functions_extra.py
+++ b/tests/test_functions_extra.py
@@ -119,3 +119,22 @@ def test_check_password_user_and_get_username(empty_db):
     assert functions.check_password_user(email, password)
     assert not functions.check_password_user(email, "wrong")
     assert functions.get_username(email) == username
+
+
+def test_get_username_by_personnummer_hash(empty_db):
+    pnr_hash = functions.hash_value("9001011234")
+    with empty_db.begin() as conn:
+        conn.execute(
+            functions.users_table.insert().values(
+                username="PersonnummerNamn",
+                email=functions.hash_value("hash@example.com"),
+                password=functions.hash_password("hemligt"),
+                personnummer=pnr_hash,
+            )
+        )
+
+    assert (
+        functions.get_username_by_personnummer_hash(pnr_hash)
+        == "PersonnummerNamn"
+    )
+    assert functions.get_username_by_personnummer_hash("saknas") is None


### PR DESCRIPTION
## Summary
- group dashboard certificates under their categories and show per-category counts
- update the dashboard template and styles to highlight grouped certificate lists

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d91705c0b8832db90b3154d482beaf