### PR TITLE
Allow admins to set categories per uploaded certificate

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -63,7 +63,8 @@ label {
 input[type="text"],
 input[type="email"],
 input[type="password"],
-input[type="file"] {
+input[type="file"],
+select {
     width: 100%;
     padding: 8px 10px;
     border: 1px solid #ccc;
@@ -147,6 +148,45 @@ a.license-link {
 a.license-link:hover {
     background: #007bff;
     color: #fff;
+}
+
+.file-category-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-top: 12px;
+}
+
+.file-category-item {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    background: #fafafa;
+}
+
+.file-category-item .file-name {
+    font-weight: 600;
+    flex: 1;
+    word-break: break-word;
+}
+
+.file-category-item select {
+    max-width: 220px;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 .not-found {

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -25,18 +25,26 @@
         </div>
     </div>
 
-    <fieldset class="category-group">
-        <legend>Välj kurskategori</legend>
-        <div class="category-options">
-            {% for slug, label in categories %}
-            <label class="radio-option">
-                <input type="radio" name="categories" value="{{ slug }}" required />
-                <span>{{ label }}</span>
-            </label>
-            {% endfor %}
-        </div>
-        <small class="hint">Välj den kategori som matchar PDF:en.</small>
+    <fieldset id="fileCategoryGroup" class="category-group" hidden>
+        <legend>Koppla kategori till varje PDF</legend>
+        <div id="fileCategoryList" class="category-options file-category-list"></div>
+        <small class="hint">Välj en kategori för varje uppladdad PDF.</small>
     </fieldset>
+
+    <template id="fileCategoryTemplate">
+        <div class="file-category-item">
+            <span class="file-name"></span>
+            <label>
+                <span class="sr-only">Kategori</span>
+                <select class="file-category-select" required>
+                    <option value="">Välj kategori</option>
+                    {% for slug, label in categories %}
+                    <option value="{{ slug }}">{{ label }}</option>
+                    {% endfor %}
+                </select>
+            </label>
+        </div>
+    </template>
 
     <button id="submitBtn" type="submit">Skapa användare</button>
 

--- a/tests/test_admin_upload.py
+++ b/tests/test_admin_upload.py
@@ -3,6 +3,7 @@ import io
 import app
 import functions
 from course_categories import COURSE_CATEGORIES
+from werkzeug.datastructures import MultiDict
 
 
 def _admin_client():
@@ -135,6 +136,56 @@ def test_admin_upload_pending_user(empty_db):
     assert rows[0].categories == COURSE_CATEGORIES[0][0]
 
 
+def test_admin_upload_multiple_pdfs_with_individual_categories(empty_db):
+    engine = empty_db
+    email = "multi@example.com"
+    username = "Multi"
+    personnummer = "19991231-0000"
+
+    assert functions.admin_create_user(email, username, personnummer)
+
+    pdf_first = b"%PDF-1.4 first"
+    pdf_second = b"%PDF-1.4 second"
+
+    data = MultiDict(
+        (
+            ("email", email),
+            ("username", username),
+            ("personnummer", personnummer),
+        )
+    )
+    data.add("pdf", (io.BytesIO(pdf_first), "first.pdf"))
+    data.add("pdf", (io.BytesIO(pdf_second), "second.pdf"))
+    data.add("categories", COURSE_CATEGORIES[0][0])
+    data.add("categories", COURSE_CATEGORIES[1][0])
+
+    with _admin_client() as client:
+        response = client.post("/admin", data=data, content_type="multipart/form-data")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "success"
+
+    personnummer_hash = functions.hash_value(
+        functions.normalize_personnummer(personnummer)
+    )
+    with engine.connect() as conn:
+        rows = list(
+            conn.execute(
+                functions.user_pdfs_table.select().where(
+                    functions.user_pdfs_table.c.personnummer == personnummer_hash
+                )
+            )
+        )
+
+    assert len(rows) == 2
+    stored = {(row.categories, row.content) for row in rows}
+    assert stored == {
+        (COURSE_CATEGORIES[0][0], pdf_first),
+        (COURSE_CATEGORIES[1][0], pdf_second),
+    }
+
+
 def test_admin_upload_requires_category(empty_db):
     pdf_bytes = b"%PDF-1.4 test"
     data = {
@@ -150,7 +201,7 @@ def test_admin_upload_requires_category(empty_db):
     assert response.status_code == 400
     payload = response.get_json()
     assert payload["status"] == "error"
-    assert payload["message"] == "Välj en kurskategori."
+    assert payload["message"] == "Välj kategori för varje PDF."
 
 
 


### PR DESCRIPTION
## Summary
- add per-file category selection controls to the admin upload form and supporting styles
- validate category lists for each uploaded certificate on the server before saving
- cover multi-PDF uploads with updated admin upload tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dac4d36a78832d8946b4b58780745e