### PR TITLE
Add share via email functionality to dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import ssl
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from html import escape
 from typing import Sequence
 from email import policy
 from email.message import EmailMessage
@@ -21,6 +24,7 @@ from smtplib import (
 
 from flask import (
     Flask,
+    Response,
     abort,
     current_app,
     jsonify,
@@ -55,6 +59,120 @@ logger.setLevel(logging.INFO)
 # functions.create_test_user()  # Skapa en testanvändare vid start
 
 
+
+
+@dataclass(frozen=True)
+class SMTPSettings:
+    server: str
+    port: int
+    user: str
+    password: str
+    timeout: int
+
+
+EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def _normalize_valid_email(address: str) -> str:
+    normalized = functions.normalize_email(address)
+    if not EMAIL_PATTERN.match(normalized):
+        raise ValueError("Ogiltig e-postadress.")
+    return normalized
+
+
+def _load_smtp_settings() -> SMTPSettings:
+    smtp_server = os.getenv("smtp_server")
+    smtp_port = int(os.getenv("smtp_port", "587"))
+    smtp_user = os.getenv("smtp_user")
+    smtp_password = os.getenv("smtp_password")
+    smtp_timeout = int(os.getenv("smtp_timeout", "10"))
+
+    if not (smtp_server and smtp_user and smtp_password):
+        raise RuntimeError("Saknar env: smtp_server, smtp_user eller smtp_password")
+
+    return SMTPSettings(
+        server=smtp_server,
+        port=smtp_port,
+        user=smtp_user,
+        password=smtp_password,
+        timeout=smtp_timeout,
+    )
+
+
+def _send_email_message(
+    msg: EmailMessage, normalized_recipient: str, settings: SMTPSettings
+) -> None:
+    context = ssl.create_default_context()
+
+    try:
+        use_ssl = settings.port == 465
+        logger.info(
+            "Förbereder utskick till %s via %s:%s (%s, timeout %ss)",
+            normalized_recipient,
+            settings.server,
+            settings.port,
+            "SSL" if use_ssl else "STARTTLS",
+            settings.timeout,
+        )
+
+        smtp_cls = SMTP_SSL if use_ssl else SMTP
+        smtp_kwargs = {"timeout": settings.timeout}
+        if use_ssl:
+            smtp_kwargs["context"] = context
+
+        with smtp_cls(settings.server, settings.port, **smtp_kwargs) as smtp:
+            if hasattr(smtp, "ehlo"):
+                smtp.ehlo()
+
+            if not use_ssl:
+                try:
+                    from inspect import signature
+
+                    if "context" in signature(smtp.starttls).parameters:
+                        smtp.starttls(context=context)
+                        logger.debug("SMTP STARTTLS initierad med kontext")
+                    else:
+                        smtp.starttls()
+                        logger.debug("SMTP STARTTLS initierad utan kontext")
+                except (TypeError, ValueError):
+                    smtp.starttls()
+                    logger.debug("SMTP STARTTLS initierad (fallback)")
+
+                if hasattr(smtp, "ehlo"):
+                    smtp.ehlo()
+
+            smtp.login(settings.user, settings.password)
+            logger.debug("SMTP inloggning lyckades för %s", settings.user)
+
+            if hasattr(smtp, "send_message"):
+                refused = smtp.send_message(msg)
+            else:
+                refused = smtp.sendmail(
+                    settings.user, [normalized_recipient], msg.as_string()
+                )
+
+            if refused:
+                logger.error("SMTP server refused recipients: %s", refused)
+                raise RuntimeError("E-postservern accepterade inte mottagaren.")
+
+        logger.debug(
+            "Meddelande-ID för utskick till %s: %s",
+            normalized_recipient,
+            msg["Message-ID"],
+        )
+
+    except SMTPAuthenticationError as exc:
+        logger.exception("SMTP login failed for %s", settings.user)
+        raise RuntimeError("SMTP-inloggning misslyckades") from exc
+    except SMTPServerDisconnected as exc:
+        logger.exception("Server closed the connection during SMTP session")
+        raise RuntimeError("Det gick inte att skicka e-post") from exc
+    except SMTPException as exc:
+        logger.exception("SMTP error when sending to %s", normalized_recipient)
+        raise RuntimeError("Det gick inte att skicka e-post") from exc
+    except OSError as exc:
+        logger.exception("Connection error to email server")
+        raise RuntimeError("Det gick inte att ansluta till e-postservern") from exc
 
 
 def _enable_debug_mode(app: Flask) -> None:
@@ -109,25 +227,18 @@ def send_creation_email(to_email: str, link: str) -> None:
     # Send a password creation link via SMTP.
 
     # Uses STARTTLS for port 587 and connects with SSL when port 465 is specified.
-    
-    normalized_email = functions.normalize_email(to_email)
+
+    normalized_email = _normalize_valid_email(to_email)
     if normalized_email != to_email:
         logger.debug(
             "Normalized recipient email from %r to %s", to_email, normalized_email
         )
 
-    smtp_server = os.getenv("smtp_server")
-    smtp_port = int(os.getenv("smtp_port", "587"))
-    smtp_user = os.getenv("smtp_user")
-    smtp_password = os.getenv("smtp_password")
-    smtp_timeout = int(os.getenv("smtp_timeout", "10"))
-
-    if not (smtp_server and smtp_user and smtp_password):
-        raise RuntimeError("Saknar env: smtp_server, smtp_user eller smtp_password")
+    settings = _load_smtp_settings()
 
     msg = EmailMessage(policy=policy.SMTP.clone(max_line_length=1000))
     msg["Subject"] = "Skapa ditt konto"
-    msg["From"] = smtp_user
+    msg["From"] = settings.user
     msg["To"] = normalized_email
     msg["Message-ID"] = make_msgid()
     msg["Date"] = format_datetime(datetime.now(timezone.utc))
@@ -145,78 +256,55 @@ def send_creation_email(to_email: str, link: str) -> None:
         subtype="html",
     )
 
-    context = ssl.create_default_context()
+    _send_email_message(msg, normalized_email, settings)
 
-    try:
-        use_ssl = smtp_port == 465
-        logger.info(
-            "Förbereder utskick till %s via %s:%s (%s, timeout %ss)",
-            normalized_email,
-            smtp_server,
-            smtp_port,
-            "SSL" if use_ssl else "STARTTLS",
-            smtp_timeout,
-        )
 
-        smtp_cls = SMTP_SSL if use_ssl else SMTP
-        smtp_kwargs = {"timeout": smtp_timeout}
-        if use_ssl:
-            smtp_kwargs["context"] = context
 
-        with smtp_cls(smtp_server, smtp_port, **smtp_kwargs) as smtp:
-            if hasattr(smtp, "ehlo"):
-                smtp.ehlo()
+def send_pdf_share_email(
+    recipient_email: str,
+    pdf_filename: str,
+    pdf_content: bytes,
+    sender_name: str,
+) -> None:
+    # Send the selected PDF as an attachment to ``recipient_email``.
 
-            if not use_ssl:
-                try:
-                    from inspect import signature
+    normalized_email = _normalize_valid_email(recipient_email)
+    settings = _load_smtp_settings()
 
-                    if "context" in signature(smtp.starttls).parameters:
-                        smtp.starttls(context=context)
-                        logger.debug("SMTP STARTTLS initierad med kontext")
-                    else:
-                        smtp.starttls()
-                        logger.debug("SMTP STARTTLS initierad utan kontext")
-                except (TypeError, ValueError):
-                    smtp.starttls()
-                    logger.debug("SMTP STARTTLS initierad (fallback)")
+    safe_sender = escape(sender_name.strip() or "En användare")
+    safe_filename = escape(pdf_filename)
 
-                if hasattr(smtp, "ehlo"):
-                    smtp.ehlo()
+    msg = EmailMessage(policy=policy.SMTP.clone(max_line_length=1000))
+    msg["Subject"] = f"Delat intyg från {safe_sender}"
+    msg["From"] = settings.user
+    msg["To"] = normalized_email
+    msg["Message-ID"] = make_msgid()
+    msg["Date"] = format_datetime(datetime.now(timezone.utc))
+    msg.set_content(
+        (
+            "<html>"
+            "<body style='font-family: Arial, sans-serif; line-height: 1.5;'>"
+            f"<p>Hej,</p>"
+            f"<p><strong>{safe_sender}</strong> har delat ett intyg med dig via JK "
+            "Utbildningsintyg.</p>"
+            f"<p>Intyget hittar du i bilagan med filnamnet <em>{safe_filename}</em>."
+            "</p>"
+            "<p>Har du frågor kan du svara direkt på detta e-postmeddelande.</p>"
+            "<p>Vänliga hälsningar,<br>JK Utbildningsintyg</p>"
+            "</body>"
+            "</html>"
+        ),
+        subtype="html",
+    )
+    msg.add_attachment(
+        pdf_content,
+        maintype="application",
+        subtype="pdf",
+        filename=pdf_filename,
+    )
 
-            smtp.login(smtp_user, smtp_password)
-            logger.debug("SMTP inloggning lyckades för %s", smtp_user)
+    _send_email_message(msg, normalized_email, settings)
 
-            if hasattr(smtp, "send_message"):
-                refused = smtp.send_message(msg)
-            else:
-                refused = smtp.sendmail(
-                    smtp_user, [normalized_email], msg.as_string()
-                )
-
-            if refused:
-                logger.error("SMTP server refused recipients: %s", refused)
-                raise RuntimeError("E-postservern accepterade inte mottagaren.")
-
-        logger.info("Skickade aktiveringslänk till %s", normalized_email)
-        logger.debug(
-            "Meddelande-ID för utskick till %s: %s",
-            normalized_email,
-            msg["Message-ID"],
-        )
-
-    except SMTPAuthenticationError as exc:
-        logger.exception("SMTP login failed for %s", smtp_user)
-        raise RuntimeError("SMTP-inloggning misslyckades") from exc
-    except SMTPServerDisconnected as exc:
-        logger.exception("Server closed the connection during SMTP session")
-        raise RuntimeError("Det gick inte att skicka e-post") from exc
-    except SMTPException as exc:
-        logger.exception("SMTP error when sending to %s", normalized_email)
-        raise RuntimeError("Det gick inte att skicka e-post") from exc
-    except OSError as exc:
-        logger.exception("Connection error to email server")
-        raise RuntimeError("Det gick inte att ansluta till e-postservern") from exc
 
 @app.context_processor
 def inject_flags():
@@ -435,6 +523,83 @@ def download_pdf(pdf_id: int):
     disposition = 'attachment' if as_attachment else 'inline'
     response.headers['Content-Disposition'] = f"{disposition}; filename=\"{filename}\""
     return response
+
+
+@app.route('/share_pdf', methods=['POST'])
+def share_pdf() -> tuple[Response, int]:
+    # Share a PDF with a recipient via e-post.
+    if not session.get('user_logged_in'):
+        logger.debug("Unauthenticated share attempt")
+        return jsonify({'fel': 'Du måste vara inloggad för att dela intyg.'}), 401
+
+    payload = request.get_json(silent=True) or request.form
+    if not payload:
+        return jsonify({'fel': 'Ogiltig begäran.'}), 400
+
+    pdf_id_raw = payload.get('pdf_id') if hasattr(payload, 'get') else None
+    recipient_email = (payload.get('recipient_email', '') if hasattr(payload, 'get') else '').strip()
+
+    try:
+        pdf_id = int(pdf_id_raw)
+    except (TypeError, ValueError):
+        logger.warning("Invalid pdf_id provided for sharing: %r", pdf_id_raw)
+        return jsonify({'fel': 'Ogiltigt intyg angivet.'}), 400
+
+    if not recipient_email:
+        return jsonify({'fel': 'Ange en e-postadress.'}), 400
+
+    pnr_hash = session.get('personnummer')
+    if not pnr_hash:
+        logger.error("Share request missing personnummer in session")
+        return jsonify({'fel': 'Saknar användaruppgifter.'}), 400
+
+    pdf = functions.get_pdf_content(pnr_hash, pdf_id)
+    if not pdf:
+        logger.warning("PDF %s not found for user %s when sharing", pdf_id, pnr_hash)
+        return jsonify({'fel': 'Intyget kunde inte hittas.'}), 404
+
+    filename, content = pdf
+
+    sender_name = session.get('username')
+    if not sender_name:
+        sender_name = functions.get_username_by_personnummer_hash(pnr_hash)
+        if sender_name:
+            session['username'] = sender_name
+
+    sender_display = (sender_name or '').strip() or 'En användare'
+
+    try:
+        normalized_recipient = _normalize_valid_email(recipient_email)
+    except ValueError:
+        return jsonify({'fel': 'Ogiltig e-postadress.'}), 400
+
+    if normalized_recipient != recipient_email:
+        logger.debug(
+            "Normalized share recipient email from %r to %s",
+            recipient_email,
+            normalized_recipient,
+        )
+
+    try:
+        send_pdf_share_email(
+            normalized_recipient,
+            filename,
+            content,
+            sender_display,
+        )
+    except RuntimeError as exc:
+        logger.exception(
+            "Failed to share pdf %s from %s to %s", pdf_id, pnr_hash, normalized_recipient
+        )
+        return jsonify({'fel': str(exc)}), 500
+
+    logger.info(
+        "User %s delade intyg %s med %s",
+        pnr_hash,
+        pdf_id,
+        normalized_recipient,
+    )
+    return jsonify({'meddelande': 'Intyget har skickats via e-post.'}), 200
 
 
 @app.route('/view_pdf/<int:pdf_id>')

--- a/app.py
+++ b/app.py
@@ -591,7 +591,7 @@ def share_pdf() -> tuple[Response, int]:
         logger.exception(
             "Failed to share pdf %s from %s to %s", pdf_id, pnr_hash, normalized_recipient
         )
-        return jsonify({'fel': str(exc)}), 500
+        return jsonify({'fel': 'Ett internt fel har inträffat.'}), 500
 
     logger.info(
         "User %s delade intyg %s med %s",

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -193,6 +193,169 @@
     font-size: 0.9rem;
 }
 
+.pdf-actions {
+    margin-top: 10px;
+}
+
+.share-button {
+    background-color: #1d4ed8;
+    color: #ffffff;
+    border: none;
+    border-radius: 8px;
+    padding: 8px 16px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.share-button:hover {
+    background-color: #153e9b;
+    box-shadow: 0 10px 18px rgba(29, 78, 216, 0.25);
+    transform: translateY(-1px);
+}
+
+.share-button:focus-visible {
+    outline: 3px solid rgba(59, 130, 246, 0.55);
+    outline-offset: 2px;
+}
+
+.share-button:disabled {
+    background-color: #9ca3af;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.share-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.share-modal.is-visible {
+    display: flex;
+}
+
+.share-modal__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+}
+
+.share-modal__dialog {
+    position: relative;
+    background-color: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 24px 40px rgba(15, 23, 42, 0.18);
+    padding: 28px 32px;
+    width: min(92%, 420px);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    z-index: 1;
+}
+
+.share-modal__close {
+    position: absolute;
+    top: 14px;
+    right: 16px;
+    background: transparent;
+    border: none;
+    font-size: 1.5rem;
+    color: #1f2937;
+    cursor: pointer;
+    transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.share-modal__close:hover {
+    color: #111827;
+    transform: scale(1.05);
+}
+
+.share-modal__close:focus-visible {
+    outline: 2px solid rgba(37, 99, 235, 0.65);
+    outline-offset: 2px;
+}
+
+.share-modal__lead {
+    margin: 0;
+    color: #4b5563;
+    font-size: 0.95rem;
+}
+
+.share-form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.share-form label {
+    font-weight: 600;
+    color: #111827;
+}
+
+.share-form input {
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    padding: 10px 12px;
+    font-size: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.share-form input:focus {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+    outline: none;
+}
+
+.share-submit {
+    align-self: flex-start;
+    background-color: #2563eb;
+    color: #ffffff;
+    border: none;
+    border-radius: 8px;
+    padding: 10px 18px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.share-submit:hover {
+    background-color: #1d4ed8;
+    box-shadow: 0 12px 20px rgba(37, 99, 235, 0.25);
+    transform: translateY(-1px);
+}
+
+.share-submit:focus-visible {
+    outline: 3px solid rgba(59, 130, 246, 0.55);
+    outline-offset: 2px;
+}
+
+.share-modal__feedback {
+    margin: 0;
+    font-size: 0.9rem;
+    min-height: 1.2em;
+}
+
+.share-modal__feedback[hidden] {
+    display: none;
+}
+
+.share-modal__feedback[data-state="success"] {
+    color: #047857;
+}
+
+.share-modal__feedback[data-state="error"] {
+    color: #b91c1c;
+}
+
+.share-modal__feedback[data-state="info"] {
+    color: #2563eb;
+}
+
 @media (max-width: 640px) {
     .dashboard {
         padding: 22px 20px;

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -9,42 +9,196 @@
   );
   const noResults = document.getElementById('noFilteredResults');
 
-  if (!checkboxes.length || !pdfItems.length) {
-    if (noResults) {
-      noResults.style.display = 'none';
+  function setupFiltering() {
+    if (!checkboxes.length || !pdfItems.length) {
+      if (noResults) {
+        noResults.style.display = 'none';
+      }
+      return;
     }
-    return;
+
+    function updateVisibility() {
+      const active = checkboxes
+        .filter((checkbox) => checkbox.checked)
+        .map((checkbox) => checkbox.value);
+
+      let visibleCount = 0;
+
+      pdfItems.forEach((item) => {
+        const categories = (item.dataset.pdfCategories || '')
+          .split(',')
+          .map((value) => value.trim())
+          .filter((value) => value);
+        const matches =
+          active.length === 0 ||
+          categories.some((category) => active.includes(category));
+
+        item.style.display = matches ? '' : 'none';
+        if (matches) {
+          visibleCount += 1;
+        }
+      });
+
+      if (noResults) {
+        noResults.style.display = visibleCount === 0 ? 'block' : 'none';
+      }
+    }
+
+    checkboxes.forEach((checkbox) => {
+      checkbox.addEventListener('change', updateVisibility);
+    });
+
+    updateVisibility();
   }
 
-  function updateVisibility() {
-    const active = checkboxes
-      .filter((checkbox) => checkbox.checked)
-      .map((checkbox) => checkbox.value);
+  function setupShareModal() {
+    const shareModal = document.getElementById('shareModal');
+    const shareForm = document.getElementById('shareForm');
+    const shareEmailInput = document.getElementById('shareRecipientEmail');
+    const shareFeedback = document.getElementById('shareFeedback');
+    const shareDocumentName = document.getElementById('shareDocumentName');
+    const closeElements = shareModal
+      ? Array.from(shareModal.querySelectorAll('[data-share-close]'))
+      : [];
+    const submitButton = shareForm
+      ? shareForm.querySelector('button[type="submit"]')
+      : null;
 
-    let visibleCount = 0;
+    if (!shareModal || !shareForm || !shareEmailInput || !submitButton) {
+      return;
+    }
 
-    pdfItems.forEach((item) => {
-      const categories = (item.dataset.pdfCategories || '')
-        .split(',')
-        .filter((value) => value);
-      const matches =
-        active.length === 0 ||
-        categories.some((category) => active.includes(category));
+    let activePdfId = null;
+    let isSubmitting = false;
 
-      item.style.display = matches ? '' : 'none';
-      if (matches) {
-        visibleCount += 1;
+    function setFeedback(message, state) {
+      if (!shareFeedback) {
+        return;
+      }
+
+      if (!message) {
+        shareFeedback.textContent = '';
+        shareFeedback.dataset.state = '';
+        shareFeedback.hidden = true;
+        return;
+      }
+
+      shareFeedback.textContent = message;
+      shareFeedback.dataset.state = state;
+      shareFeedback.hidden = false;
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeShareModal();
+      }
+    };
+
+    function openShareModal(pdfId, pdfName) {
+      activePdfId = pdfId;
+      shareModal.classList.add('is-visible');
+      shareModal.setAttribute('aria-hidden', 'false');
+      setFeedback('', '');
+      shareEmailInput.value = '';
+      shareEmailInput.focus();
+      if (shareDocumentName) {
+        shareDocumentName.textContent = pdfName || 'intyget';
+      }
+      document.addEventListener('keydown', handleKeyDown);
+    }
+
+    function closeShareModal() {
+      activePdfId = null;
+      shareModal.classList.remove('is-visible');
+      shareModal.setAttribute('aria-hidden', 'true');
+      setFeedback('', '');
+      document.removeEventListener('keydown', handleKeyDown);
+    }
+
+    closeElements.forEach((element) => {
+      element.addEventListener('click', () => {
+        closeShareModal();
+      });
+    });
+
+    shareForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+
+      if (isSubmitting) {
+        return;
+      }
+
+      const email = shareEmailInput.value.trim();
+      if (!email) {
+        setFeedback('Ange en e-postadress.', 'error');
+        shareEmailInput.focus();
+        return;
+      }
+
+      if (!activePdfId) {
+        setFeedback('Det gick inte att identifiera intyget.', 'error');
+        return;
+      }
+
+      isSubmitting = true;
+      submitButton.disabled = true;
+      setFeedback('Skickar intyget...', 'info');
+
+      try {
+        const response = await fetch('/share_pdf', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          body: JSON.stringify({
+            pdf_id: activePdfId,
+            recipient_email: email,
+          }),
+        });
+
+        const data = await response.json().catch(() => ({}));
+
+        if (response.ok) {
+          setFeedback(
+            data.meddelande || 'Intyget har skickats.',
+            'success'
+          );
+          shareEmailInput.value = '';
+        } else {
+          setFeedback(
+            data.fel || 'Det gick inte att skicka intyget.',
+            'error'
+          );
+        }
+      } catch (error) {
+        setFeedback('Det gick inte att ansluta till servern.', 'error');
+      } finally {
+        isSubmitting = false;
+        submitButton.disabled = false;
       }
     });
 
-    if (noResults) {
-      noResults.style.display = visibleCount === 0 ? 'block' : 'none';
-    }
+    const shareButtons = Array.from(
+      document.querySelectorAll('[data-share-button]')
+    );
+
+    shareButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const pdfId = Number.parseInt(button.dataset.pdfId || '', 10);
+        const pdfName = button.dataset.pdfName || 'intyget';
+
+        if (!Number.isInteger(pdfId)) {
+          setFeedback('Det gick inte att identifiera intyget.', 'error');
+          return;
+        }
+
+        openShareModal(pdfId, pdfName);
+      });
+    });
   }
 
-  checkboxes.forEach((checkbox) => {
-    checkbox.addEventListener('change', updateVisibility);
-  });
-
-  updateVisibility();
+  setupFiltering();
+  setupShareModal();
 })();

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -48,8 +48,19 @@
                             Inte angiven
                         {% endif %}
                         <br>
-                        
+
                     </span>
+                    <div class="pdf-actions">
+                        <button
+                            type="button"
+                            class="share-button"
+                            data-share-button
+                            data-pdf-id="{{ pdf.id }}"
+                            data-pdf-name="{{ pdf.filename }}"
+                        >
+                            Dela via e-post
+                        </button>
+                    </div>
                 </li>
                 {% endfor %}
             </ul>
@@ -60,4 +71,29 @@
     <p>Inga PDF:er uppladdade.</p>
     {% endif %}
 </section>
+
+<div id="shareModal" class="share-modal" aria-hidden="true">
+    <div class="share-modal__backdrop" data-share-close></div>
+    <div class="share-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="shareModalTitle">
+        <button type="button" class="share-modal__close" aria-label="Stäng delningsrutan" data-share-close>&times;</button>
+        <h2 id="shareModalTitle">Dela intyg via e-post</h2>
+        <p class="share-modal__lead">
+            Du delar <strong id="shareDocumentName">intyget</strong>. Ange mottagarens e-postadress nedan.
+        </p>
+        <form id="shareForm" class="share-form" novalidate>
+            <label for="shareRecipientEmail">Mottagarens e-postadress</label>
+            <input
+                type="email"
+                id="shareRecipientEmail"
+                name="recipient_email"
+                required
+                autocomplete="email"
+                placeholder="namn@example.se"
+            >
+            <button type="submit" class="share-submit">Skicka intyget</button>
+        </form>
+        <p class="share-modal__feedback" id="shareFeedback" role="alert" hidden></p>
+    </div>
+</div>
+<script src="{{ url_for('static', filename='js/dashboard.js') }}"></script>
 {% endblock %}

--- a/tests/test_share_pdf.py
+++ b/tests/test_share_pdf.py
@@ -1,0 +1,122 @@
+import app
+import functions
+import pytest
+
+from course_categories import COURSE_CATEGORIES
+
+
+def _login_default_user(client):
+    return client.post(
+        "/login",
+        data={"personnummer": "9001011234", "password": "secret"},
+        follow_redirects=False,
+    )
+
+
+def _store_sample_pdf() -> int:
+    personnummer_hash = functions.hash_value("9001011234")
+    return functions.store_pdf_blob(
+        personnummer_hash,
+        "delningstest.pdf",
+        b"%PDF-1.4 sample",
+        [COURSE_CATEGORIES[0][0]],
+    )
+
+
+def _set_mail_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("smtp_server", "smtp.example.com")
+    monkeypatch.setenv("smtp_port", "587")
+    monkeypatch.setenv("smtp_user", "info@example.com")
+    monkeypatch.setenv("smtp_password", "hemligt")
+    monkeypatch.setenv("smtp_timeout", "10")
+
+
+def test_share_pdf_requires_login(user_db):
+    pdf_id = _store_sample_pdf()
+
+    with app.app.test_client() as client:
+        response = client.post(
+            "/share_pdf",
+            json={"pdf_id": pdf_id, "recipient_email": "mottagare@example.com"},
+        )
+
+    assert response.status_code == 401
+
+
+def test_share_pdf_sends_email(monkeypatch, user_db):
+    _set_mail_env(monkeypatch)
+    pdf_id = _store_sample_pdf()
+
+    sent = {}
+
+    def fake_sender(message, recipient, settings):
+        sent["message"] = message
+        sent["recipient"] = recipient
+        sent["settings"] = settings
+
+    monkeypatch.setattr(app, "_send_email_message", fake_sender)
+
+    with app.app.test_client() as client:
+        _login_default_user(client)
+        response = client.post(
+            "/share_pdf",
+            json={
+                "pdf_id": pdf_id,
+                "recipient_email": "mottagare@example.com",
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["meddelande"] == "Intyget har skickats via e-post."
+
+    assert sent["recipient"] == "mottagare@example.com"
+    assert sent["settings"].user == "info@example.com"
+
+    message = sent["message"]
+    assert message["To"] == "mottagare@example.com"
+    assert message["From"] == "info@example.com"
+
+    html_part = message.get_body(preferencelist=("html", "plain"))
+    assert html_part is not None
+    assert "Test" in html_part.get_content()
+
+    attachments = list(message.iter_attachments())
+    assert len(attachments) == 1
+    attachment = attachments[0]
+    assert attachment.get_filename() == "delningstest.pdf"
+    assert attachment.get_content_type() == "application/pdf"
+
+
+def test_share_pdf_rejects_invalid_email(monkeypatch, user_db):
+    _set_mail_env(monkeypatch)
+    pdf_id = _store_sample_pdf()
+
+    monkeypatch.setattr(app, "_send_email_message", lambda *args, **kwargs: None)
+
+    with app.app.test_client() as client:
+        _login_default_user(client)
+        response = client.post(
+            "/share_pdf",
+            json={"pdf_id": pdf_id, "recipient_email": "fel-adress"},
+        )
+
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "Ogiltig e-postadress" in data["fel"]
+
+
+def test_share_pdf_missing_document(monkeypatch, user_db):
+    _set_mail_env(monkeypatch)
+    monkeypatch.setattr(app, "_send_email_message", lambda *args, **kwargs: None)
+
+    with app.app.test_client() as client:
+        _login_default_user(client)
+        response = client.post(
+            "/share_pdf",
+            json={"pdf_id": 9999, "recipient_email": "mottagare@example.com"},
+        )
+
+    assert response.status_code == 404
+    data = response.get_json()
+    assert "kunde inte hittas" in data["fel"]


### PR DESCRIPTION
## Summary
- add SMTP helpers that validate email addresses and support reusable delivery
- send shared certificates as PDF attachments and expose a /share_pdf endpoint
- extend the dashboard UI with a share modal, styling, and JavaScript behaviour, plus regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dac753d220832daf186864bb0d669a