### PR TITLE
Add dashboard mailto link for data deletion requests

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -12,6 +12,48 @@
     color: #1f2937;
 }
 
+.support-actions {
+    margin: 0 0 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: flex-start;
+}
+
+.support-text {
+    margin: 0;
+    font-size: 1rem;
+    color: #374151;
+}
+
+.support-email-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: #f3f4f6;
+    color: #1f2937;
+    text-decoration: none;
+    padding: 6px 14px;
+    border-radius: 8px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    border: 1px solid #d1d5db;
+    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    box-shadow: none;
+}
+
+.support-email-button:hover,
+.support-email-button:focus {
+    background: #e5e7eb;
+    border-color: #cbd5e1;
+    color: #111827;
+}
+
+.support-email-button:focus {
+    outline: 2px solid rgba(59, 130, 246, 0.35);
+    outline-offset: 2px;
+}
+
 .category-list {
     margin-bottom: 28px;
     border: 1px solid #e5e7eb;

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -12,6 +12,10 @@
             Hej! Här är dina intyg.
         {% endif %}
     </h1>
+    <div class="support-actions" aria-label="Sektion för att kontakta supporten">
+        <p class="support-text">Behöver du radera dina uppgifter? Kontakta oss så hjälper vi dig.</p>
+        <a class="support-email-button" href="mailto:support@utbildningsintyg.se?subject=Beg%C3%A4ran%20om%20radering%20av%20anv%C3%A4ndardata&body=Hej%20supportteamet%2C%0A%0AJag%20vill%20beg%C3%A4ra%20att%20all%20min%20anv%C3%A4ndardata%20tas%20bort.%0A%0AV%C3%A4nligen%20bekr%C3%A4fta%20n%C3%A4r%20det%20%C3%A4r%20klart.%0A%0ATack!">Begär radering av mina uppgifter</a>
+    </div>
     {% if category_summary %}
     <section class="category-list" aria-label="Tillgängliga kurskategorier">
         <h2>Kurskategorier</h2>


### PR DESCRIPTION
## Summary
- add a dashboard call-to-action that opens an email to support for data deletion requests
- refine the mailto button styling so the prompt is smaller and more återhållsam while retaining clear focus states

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68daca9c37c0832dbfc4a47d37c927a2