### PR TITLE
Add admin management and password reset tools

### DIFF
--- a/static/js/admin_manage.js
+++ b/static/js/admin_manage.js
@@ -1,0 +1,222 @@
+(function () {
+    const categoryDataElement = document.getElementById('categoryData');
+    const categories = categoryDataElement ? JSON.parse(categoryDataElement.textContent) : [];
+
+    const searchForm = document.getElementById('searchForm');
+    const searchInput = document.getElementById('searchPersonnummer');
+    const resultsSection = document.getElementById('pdfResults');
+    const tableBody = document.querySelector('#pdfTable tbody');
+    const messageBox = document.getElementById('adminMessage');
+    const currentUserLabel = document.getElementById('currentUser');
+    const resetForm = document.getElementById('resetForm');
+    let currentPersonnummer = '';
+
+    function showMessage(text, isError = false) {
+        if (!messageBox) {
+            return;
+        }
+        if (!text) {
+            messageBox.style.display = 'none';
+            return;
+        }
+        messageBox.style.display = 'block';
+        messageBox.textContent = text;
+        messageBox.classList.toggle('error', Boolean(isError));
+        messageBox.classList.toggle('success', !isError);
+    }
+
+    function formatDate(value) {
+        if (!value) {
+            return '–';
+        }
+        try {
+            const date = new Date(value);
+            if (Number.isNaN(date.getTime())) {
+                return value;
+            }
+            return date.toLocaleString('sv-SE');
+        } catch (err) {
+            return value;
+        }
+    }
+
+    function createCategorySelect(selected) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'category-select-wrapper';
+        const select = document.createElement('select');
+        select.multiple = true;
+        select.className = 'category-select';
+
+        categories.forEach(([slug, label]) => {
+            const option = document.createElement('option');
+            option.value = slug;
+            option.textContent = label;
+            if (selected.includes(slug)) {
+                option.selected = true;
+            }
+            select.appendChild(option);
+        });
+
+        wrapper.appendChild(select);
+        return { wrapper, select };
+    }
+
+    function renderTable(pdfs) {
+        tableBody.innerHTML = '';
+        if (!pdfs.length) {
+            const row = document.createElement('tr');
+            const cell = document.createElement('td');
+            cell.colSpan = 5;
+            cell.textContent = 'Inga PDF:er hittades för detta personnummer.';
+            row.appendChild(cell);
+            tableBody.appendChild(row);
+            return;
+        }
+
+        pdfs.forEach((pdf) => {
+            const row = document.createElement('tr');
+
+            const idCell = document.createElement('td');
+            idCell.textContent = String(pdf.id);
+            row.appendChild(idCell);
+
+            const nameCell = document.createElement('td');
+            nameCell.textContent = pdf.filename;
+            row.appendChild(nameCell);
+
+            const categoriesCell = document.createElement('td');
+            const { wrapper, select } = createCategorySelect(pdf.categories || []);
+            categoriesCell.appendChild(wrapper);
+            row.appendChild(categoriesCell);
+
+            const uploadedCell = document.createElement('td');
+            uploadedCell.textContent = formatDate(pdf.uploaded_at);
+            row.appendChild(uploadedCell);
+
+            const actionsCell = document.createElement('td');
+            actionsCell.className = 'actions-cell';
+
+            const saveButton = document.createElement('button');
+            saveButton.type = 'button';
+            saveButton.textContent = 'Spara kategorier';
+            saveButton.addEventListener('click', async () => {
+                const selectedValues = Array.from(select.selectedOptions).map((option) => option.value);
+                if (!selectedValues.length) {
+                    showMessage('Välj minst en kategori.', true);
+                    return;
+                }
+                await updateCategories(pdf.id, selectedValues, select);
+            });
+
+            const deleteButton = document.createElement('button');
+            deleteButton.type = 'button';
+            deleteButton.className = 'danger';
+            deleteButton.textContent = 'Ta bort';
+            deleteButton.addEventListener('click', async () => {
+                if (!window.confirm('Är du säker på att du vill ta bort PDF:en?')) {
+                    return;
+                }
+                await deletePdf(pdf.id);
+            });
+
+            actionsCell.appendChild(saveButton);
+            actionsCell.appendChild(deleteButton);
+            row.appendChild(actionsCell);
+
+            tableBody.appendChild(row);
+        });
+    }
+
+    async function fetchJson(url, body) {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        const data = await response.json();
+        if (!response.ok || data.status !== 'success') {
+            const errorMessage = data && data.message ? data.message : 'Ett okänt fel inträffade.';
+            throw new Error(errorMessage);
+        }
+        return data;
+    }
+
+    async function loadPdfs(personnummer) {
+        showMessage('Hämtar PDF:er …');
+        try {
+            const data = await fetchJson('/admin/hantera/pdfer', { personnummer });
+            currentPersonnummer = personnummer;
+            currentUserLabel.textContent = `Personnummer: ${personnummer}`;
+            renderTable(data.pdfs || []);
+            resultsSection.hidden = false;
+            showMessage('PDF:er hämtade.', false);
+        } catch (error) {
+            resultsSection.hidden = true;
+            showMessage(error.message, true);
+        }
+    }
+
+    async function deletePdf(pdfId) {
+        try {
+            const data = await fetchJson('/admin/hantera/radera_pdf', {
+                personnummer: currentPersonnummer,
+                pdf_id: pdfId,
+            });
+            showMessage(data.message || 'PDF borttagen.');
+            await loadPdfs(currentPersonnummer);
+        } catch (error) {
+            showMessage(error.message, true);
+        }
+    }
+
+    async function updateCategories(pdfId, categoriesList, selectElement) {
+        try {
+            const data = await fetchJson('/admin/hantera/uppdatera_kategorier', {
+                personnummer: currentPersonnummer,
+                pdf_id: pdfId,
+                categories: categoriesList,
+            });
+            showMessage(data.message || 'Kategorier uppdaterade.');
+            if (data.categories && Array.isArray(data.categories)) {
+                const options = Array.from(selectElement.options);
+                options.forEach((option) => {
+                    option.selected = data.categories.includes(option.value);
+                });
+            }
+        } catch (error) {
+            showMessage(error.message, true);
+        }
+    }
+
+    if (searchForm) {
+        searchForm.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            const value = searchInput.value.trim();
+            if (!value) {
+                showMessage('Ange ett personnummer.', true);
+                return;
+            }
+            await loadPdfs(value);
+        });
+    }
+
+    if (resetForm) {
+        resetForm.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            const emailInput = document.getElementById('resetEmail');
+            const email = emailInput ? emailInput.value.trim() : '';
+            if (!email) {
+                showMessage('Ange en e-postadress.', true);
+                return;
+            }
+            showMessage('Skickar återställningslänk …');
+            try {
+                const data = await fetchJson('/admin/hantera/skicka_aterstallning', { email });
+                showMessage(data.message || 'Återställningslänk skickad.');
+                resetForm.reset();
+            } catch (error) {
+                showMessage(error.message, true);
+            }
+        });
+    }
+})();

--- a/templates/admin_database.html
+++ b/templates/admin_database.html
@@ -1,0 +1,41 @@
+{% block title %}Admin — Databastool{% endblock %}
+{% block content %}
+<h1>Admin — Databastool</h1>
+<p>Här kan du köra egna SQL-kommandon mot databasen. Var försiktig med ändringar.</p>
+
+{% if error %}
+<div class="message error">{{ error }}</div>
+{% endif %}
+{% if message %}
+<div class="message success">{{ message }}</div>
+{% endif %}
+
+<form method="post" class="admin-section">
+    <label for="sql">SQL-fråga</label>
+    <textarea id="sql" name="sql" rows="6" required>{{ query }}</textarea>
+    <button type="submit">Kör fråga</button>
+</form>
+
+{% if columns %}
+<table class="admin-table">
+    <thead>
+        <tr>
+            {% for column in columns %}
+            <th>{{ column }}</th>
+            {% endfor %}
+        </tr>
+    </thead>
+    <tbody>
+        {% for row in rows %}
+        <tr>
+            {% for cell in row %}
+            <td>{{ cell }}</td>
+            {% endfor %}
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% elif rows is not none %}
+<p>Frågan returnerade inga rader.</p>
+{% endif %}
+{% endblock %}

--- a/templates/admin_manage.html
+++ b/templates/admin_manage.html
@@ -1,0 +1,45 @@
+{% block title %}Admin — Hantera intyg{% endblock %}
+{% block content %}
+<h1>Admin — Hantera intyg</h1>
+<p>Hantera uppladdade PDF-intyg, justera kategorier och skicka återställningslänkar.</p>
+
+<section class="admin-section">
+    <h2>Sök användare</h2>
+    <form id="searchForm" autocomplete="off">
+        <label for="searchPersonnummer">Personnummer</label>
+        <input id="searchPersonnummer" name="personnummer" type="text" placeholder="ÅÅMMDDXXXX" required>
+        <button type="submit">Hämta PDF:er</button>
+    </form>
+    <div id="adminMessage" class="message" role="status" style="display:none"></div>
+</section>
+
+<section id="pdfResults" class="admin-section" hidden>
+    <h2>Registrerade PDF:er</h2>
+    <p id="currentUser"></p>
+    <table id="pdfTable">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Filnamn</th>
+                <th>Kategorier</th>
+                <th>Uppladdad</th>
+                <th>Åtgärder</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+</section>
+
+<section class="admin-section">
+    <h2>Skicka återställningslänk</h2>
+    <form id="resetForm" autocomplete="off">
+        <label for="resetEmail">E-postadress</label>
+        <input id="resetEmail" name="email" type="email" placeholder="användare@example.com" required>
+        <button type="submit">Skicka återställning</button>
+    </form>
+    <p class="hint">En återställningslänk skickas till användaren och är giltig i 24 timmar.</p>
+</section>
+
+<script id="categoryData" type="application/json">{{ categories | tojson }}</script>
+<script src="{{ url_for('static', filename='js/admin_manage.js') }}"></script>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,6 +17,8 @@
                 <a href="/logout">Logga ut</a>
             {% elif session.get('admin_logged_in') %}
                 <a href="/admin">Admin</a>
+                <a href="/admin/hantera">Hantera intyg</a>
+                <a href="/admin/databas">Databastool</a>
                 <a href="/logout">Logga ut</a>
             {% else %}
                 <a href="/login">Logga in</a>

--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -1,0 +1,17 @@
+{% block title %}Återställ lösenord{% endblock %}
+{% block content %}
+<h1>Återställ lösenord</h1>
+{% if invalid %}
+<p class="message error">Länken är ogiltig eller har löpt ut. Begär en ny återställning från administratören.</p>
+{% else %}
+<p>Ange ett nytt lösenord för {{ username }}.</p>
+{% if error %}
+<p class="message error">{{ error }}</p>
+{% endif %}
+<form method="post">
+    <label for="password">Nytt lösenord</label>
+    <input id="password" name="password" type="password" required>
+    <button type="submit">Uppdatera lösenord</button>
+</form>
+{% endif %}
+{% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ def user_db(tmp_path, monkeypatch):
             functions.users_table.insert().values(
                 username="Test",
                 email=functions.hash_value("test@example.com"),
+                email_plain=functions.normalize_email("test@example.com"),
                 password=functions.hash_password("secret"),
                 personnummer=functions.hash_value("9001011234"),
             )

--- a/tests/test_admin_manage.py
+++ b/tests/test_admin_manage.py
@@ -1,0 +1,130 @@
+import app
+import functions
+
+
+def _admin_client():
+    client = app.app.test_client()
+    with client.session_transaction() as sess:
+        sess['admin_logged_in'] = True
+    return client
+
+
+def _create_user_with_pdf(engine, email='user@example.com', personnummer='19900101-1234'):
+    email_norm = functions.normalize_email(email)
+    email_hash = functions.hash_value(email_norm)
+    pnr_norm = functions.normalize_personnummer(personnummer)
+    pnr_hash = functions.hash_value(pnr_norm)
+    with engine.begin() as conn:
+        conn.execute(
+            functions.users_table.insert().values(
+                username='Användare',
+                email=email_hash,
+                email_plain=email_norm,
+                password=functions.hash_password('hemligt'),
+                personnummer=pnr_hash,
+            )
+        )
+    pdf_id = functions.store_pdf_blob(pnr_hash, 'intyg.pdf', b'PDF-DATA', ['fallskydd'])
+    return pnr_norm, pdf_id
+
+
+def test_admin_manage_requires_login(empty_db):
+    client = app.app.test_client()
+    response = client.get('/admin/hantera')
+    assert response.status_code == 302
+    response = client.post('/admin/hantera/pdfer', json={'personnummer': '19900101-1234'})
+    assert response.status_code == 403
+
+
+def test_admin_manage_list_update_and_delete_pdf(empty_db):
+    engine = empty_db
+    personnummer, pdf_id = _create_user_with_pdf(engine)
+
+    with _admin_client() as client:
+        response = client.post('/admin/hantera/pdfer', json={'personnummer': personnummer})
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['status'] == 'success'
+        assert len(data['pdfs']) == 1
+        assert data['pdfs'][0]['id'] == pdf_id
+
+        update_response = client.post(
+            '/admin/hantera/uppdatera_kategorier',
+            json={
+                'personnummer': personnummer,
+                'pdf_id': pdf_id,
+                'categories': ['lift', 'truck'],
+            },
+        )
+        assert update_response.status_code == 200
+        update_data = update_response.get_json()
+        assert update_data['status'] == 'success'
+        assert set(update_data['categories']) == {'lift', 'truck'}
+
+    with engine.connect() as conn:
+        row = conn.execute(
+            functions.user_pdfs_table.select().where(
+                functions.user_pdfs_table.c.id == pdf_id
+            )
+        ).first()
+    assert row is not None
+    assert row.categories in {'lift,truck', 'truck,lift'}
+
+    with _admin_client() as client:
+        delete_response = client.post(
+            '/admin/hantera/radera_pdf',
+            json={'personnummer': personnummer, 'pdf_id': pdf_id},
+        )
+        assert delete_response.status_code == 200
+        delete_data = delete_response.get_json()
+        assert delete_data['status'] == 'success'
+
+    with engine.connect() as conn:
+        remaining = conn.execute(
+            functions.user_pdfs_table.select().where(
+                functions.user_pdfs_table.c.id == pdf_id
+            )
+        ).first()
+    assert remaining is None
+
+
+def test_admin_manage_send_reset_and_use_link(empty_db, monkeypatch):
+    engine = empty_db
+    personnummer, _ = _create_user_with_pdf(engine)
+    sent_links = []
+
+    def fake_send_email(address, link, username=None):
+        sent_links.append(link)
+
+    monkeypatch.setattr(app, 'send_password_reset_email', fake_send_email)
+
+    with _admin_client() as client:
+        response = client.post(
+            '/admin/hantera/skicka_aterstallning',
+            json={'email': 'user@example.com'},
+        )
+        assert response.status_code == 200
+        payload = response.get_json()
+        assert payload['status'] == 'success'
+
+    assert sent_links, 'Reset email should have been sent'
+
+    with engine.connect() as conn:
+        token_row = conn.execute(functions.password_resets_table.select()).first()
+    assert token_row is not None
+    token = token_row.token
+
+    with app.app.test_client() as client:
+        get_response = client.get(f'/aterstall/{token}')
+        assert get_response.status_code == 200
+        assert 'Nytt lösenord' in get_response.get_data(as_text=True)
+
+        post_response = client.post(
+            f'/aterstall/{token}',
+            data={'password': 'nyttlosen'},
+            follow_redirects=False,
+        )
+        assert post_response.status_code == 302
+        assert post_response.headers['Location'].endswith('/login')
+
+    assert functions.check_personnummer_password(personnummer, 'nyttlosen')

--- a/tests/test_admin_upload.py
+++ b/tests/test_admin_upload.py
@@ -20,6 +20,7 @@ def test_admin_upload_existing_user_only_saves_pdf(empty_db):
             functions.users_table.insert().values(
                 username="Existing",
                 email=functions.hash_value("exist@example.com"),
+                email_plain=functions.normalize_email("exist@example.com"),
                 password=functions.hash_password("secret"),
                 personnummer=functions.hash_value("9001011234"),
             )
@@ -61,6 +62,7 @@ def test_admin_upload_existing_email(empty_db):
             functions.users_table.insert().values(
                 username="Existing",
                 email=functions.hash_value("exist@example.com"),
+                email_plain=functions.normalize_email("exist@example.com"),
                 password=functions.hash_password("secret"),
                 personnummer=functions.hash_value("9001011234"),
             )

--- a/tests/test_functions_additional.py
+++ b/tests/test_functions_additional.py
@@ -27,6 +27,7 @@ def test_admin_and_user_create_flow(empty_db, monkeypatch):
         pending_row = conn.execute(functions.pending_users_table.select()).first()
     assert pending_row is not None
     assert pending_row.email == functions.hash_value(email)
+    assert pending_row.email_plain == functions.normalize_email(email)
     assert pending_row.username == username
 
     pnr_hash = functions.hash_value(functions.normalize_personnummer(personnummer))
@@ -43,6 +44,7 @@ def test_admin_and_user_create_flow(empty_db, monkeypatch):
 
     assert pending_after is None
     assert user_row is not None
+    assert user_row.email_plain == functions.normalize_email(email)
 
     functions.verify_certificate.cache_clear()
     assert functions.verify_certificate(personnummer)

--- a/tests/test_functions_extra.py
+++ b/tests/test_functions_extra.py
@@ -45,6 +45,7 @@ def test_admin_create_user_duplicate(empty_db):
             functions.users_table.insert().values(
                 username="Existing",
                 email=functions.hash_value("exist@example.com"),
+                email_plain=functions.normalize_email("exist@example.com"),
                 password=functions.hash_password("secret"),
                 personnummer=functions.hash_value("9001011234"),
             )
@@ -58,6 +59,7 @@ def test_check_personnummer_password(empty_db):
             functions.users_table.insert().values(
                 username="Test",
                 email=functions.hash_value("test@example.com"),
+                email_plain=functions.normalize_email("test@example.com"),
                 password=functions.hash_password("secret"),
                 personnummer=functions.hash_value("9001011234"),
             )
@@ -72,6 +74,7 @@ def test_get_user_info(empty_db):
             functions.users_table.insert().values(
                 username="Info",
                 email=functions.hash_value("info@example.com"),
+                email_plain=functions.normalize_email("info@example.com"),
                 password=functions.hash_password("pass"),
                 personnummer=functions.hash_value("9001011234"),
             )
@@ -89,6 +92,7 @@ def test_user_create_user_fails_if_exists(empty_db):
             functions.users_table.insert().values(
                 username="Existing",
                 email=functions.hash_value("exist@example.com"),
+                email_plain=functions.normalize_email("exist@example.com"),
                 password=functions.hash_password("secret"),
                 personnummer=pnr_hash,
             )
@@ -111,6 +115,7 @@ def test_check_password_user_and_get_username(empty_db):
             functions.users_table.insert().values(
                 username=username,
                 email=functions.hash_value(email),
+                email_plain=functions.normalize_email(email),
                 password=functions.hash_password(password),
                 personnummer=functions.hash_value("9001011234"),
             )
@@ -128,6 +133,7 @@ def test_get_username_by_personnummer_hash(empty_db):
             functions.users_table.insert().values(
                 username="PersonnummerNamn",
                 email=functions.hash_value("hash@example.com"),
+                email_plain=functions.normalize_email("hash@example.com"),
                 password=functions.hash_password("hemligt"),
                 personnummer=pnr_hash,
             )

--- a/tests/test_functions_more.py
+++ b/tests/test_functions_more.py
@@ -18,6 +18,7 @@ def test_admin_create_user_single_pdf(empty_db):
     with empty_db.connect() as conn:
         row = conn.execute(functions.pending_users_table.select()).first()
     assert row.email == functions.hash_value(email)
+    assert row.email_plain == functions.normalize_email(email)
     assert row.username == username
 
 

--- a/tests/test_user_create.py
+++ b/tests/test_user_create.py
@@ -7,6 +7,7 @@ def test_user_create_hashes_password(empty_db):
         conn.execute(
             functions.pending_users_table.insert().values(
                 email=functions.hash_value("user@example.com"),
+                email_plain="user@example.com",
                 username="User",
                 personnummer=pnr_hash,
             )

--- a/tests/test_user_management.py
+++ b/tests/test_user_management.py
@@ -13,6 +13,7 @@ def test_check_user_exists(empty_db):
             functions.users_table.insert().values(
                 username="Exists",
                 email=functions.hash_value(email),
+                email_plain=functions.normalize_email(email),
                 password=functions.hash_password("pass"),
                 personnummer=functions.hash_value("9001011234"),
             )
@@ -47,5 +48,6 @@ def test_user_create_user_success(empty_db):
     assert pending is None
     assert user_row is not None
     assert user_row.email == functions.hash_value(email)
+    assert user_row.email_plain == functions.normalize_email(email)
     assert user_row.username == username
     assert functions.check_user_exists(email)

--- a/tests/test_user_queries.py
+++ b/tests/test_user_queries.py
@@ -15,6 +15,7 @@ def test_verify_certificate_existing_user(empty_db):
             functions.users_table.insert().values(
                 username="Test",
                 email=functions.hash_value("user@example.com"),
+                email_plain=functions.normalize_email("user@example.com"),
                 password=functions.hash_password("secret"),
                 personnummer=functions.hash_value("9001011234"),
             )
@@ -31,6 +32,7 @@ def test_check_user_exists(empty_db):
             functions.users_table.insert().values(
                 username="Tester",
                 email=functions.hash_value(email),
+                email_plain=functions.normalize_email(email),
                 password=functions.hash_password("pass"),
                 personnummer=functions.hash_value("9001011234"),
             )


### PR DESCRIPTION
## Summary
- add a password-protected administration page to view, update, and delete användares PDF-intyg samt skicka återställningslänkar
- expose an avancerat databastool för administratörer och stöd för återställningssidor med nytt lösenord
- store klartext-e-post i databasen och uppdatera tester samt front-end-resurser för den nya funktionaliteten

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68daca1ab5d8832d9e8af43be7c1a6c6