### PR TITLE
Add admin dashboard management tools and advanced editor

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -361,3 +361,98 @@ footer {
         max-width: 100%;
     }
 }
+
+.message.error {
+    color: #6e1b1b;
+}
+
+.panel {
+    margin: 2rem 0;
+    padding: 1.5rem;
+    background: #f8f9fb;
+    border: 1px solid #dde2ea;
+    border-radius: 8px;
+}
+
+.panel h2 {
+    margin-top: 0;
+}
+
+.inline-form {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 1rem;
+}
+
+.inline-form input,
+.inline-form select,
+.inline-form button {
+    margin-bottom: 0;
+}
+
+.stacked-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-width: 420px;
+}
+
+.button {
+    display: inline-block;
+    background: #0b6aa2;
+    color: #fff;
+    padding: 0.75rem 1.2rem;
+    border-radius: 4px;
+    text-decoration: none;
+}
+
+.button:hover,
+.button:focus {
+    background: #094f78;
+}
+
+button.danger {
+    background: #b3261e;
+    color: #fff;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+button.danger:hover,
+button.danger:focus {
+    background: #8b1d17;
+}
+
+.responsive-table {
+    overflow-x: auto;
+}
+
+.panel table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+}
+
+.panel th,
+.panel td {
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid #d4dae2;
+    text-align: left;
+}
+
+.panel th {
+    background: #eef2f7;
+}
+
+.category-select {
+    min-width: 180px;
+}
+
+.button-row {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}

--- a/static/js/admin_advanced.js
+++ b/static/js/admin_advanced.js
@@ -1,0 +1,214 @@
+(function () {
+  const tableForm = document.getElementById('tableForm');
+  const tableSelect = document.getElementById('tableSelect');
+  const searchInput = document.getElementById('searchInput');
+  const tableStatus = document.getElementById('tableStatus');
+  const tableContainer = document.getElementById('tableContainer');
+  const tableHead = document.getElementById('tableHead');
+  const tableBody = document.getElementById('tableBody');
+  const rowIdInput = document.getElementById('rowIdInput');
+  const payloadInput = document.getElementById('payloadInput');
+  const createBtn = document.getElementById('createBtn');
+  const updateBtn = document.getElementById('updateBtn');
+  const deleteBtn = document.getElementById('deleteBtn');
+  const editorMessage = document.getElementById('editorMessage');
+  let currentSchema = [];
+
+  function setTableStatus(message, isError) {
+    if (!tableStatus) return;
+    tableStatus.textContent = message || '';
+    tableStatus.classList.toggle('error', Boolean(isError));
+  }
+
+  function setEditorMessage(message, isError) {
+    if (!editorMessage) return;
+    editorMessage.textContent = message || '';
+    editorMessage.classList.toggle('error', Boolean(isError));
+  }
+
+  function renderTable(rows) {
+    if (!Array.isArray(rows) || rows.length === 0) {
+      tableContainer.hidden = true;
+      setTableStatus('Inga poster att visa.', false);
+      return;
+    }
+    if (currentSchema.length === 0) {
+      currentSchema = Object.keys(rows[0]).map((name) => ({ name }));
+    }
+    tableHead.innerHTML = '';
+    tableBody.innerHTML = '';
+
+    const headRow = document.createElement('tr');
+    currentSchema.forEach((column) => {
+      const th = document.createElement('th');
+      th.textContent = column.name;
+      headRow.appendChild(th);
+    });
+    tableHead.appendChild(headRow);
+
+    rows.forEach((row) => {
+      const tr = document.createElement('tr');
+      currentSchema.forEach((column) => {
+        const td = document.createElement('td');
+        const value = row[column.name];
+        if (typeof value === 'string' && value.length > 120) {
+          td.textContent = value.slice(0, 120) + '…';
+        } else if (value === null || value === undefined) {
+          td.textContent = '';
+        } else {
+          td.textContent = String(value);
+        }
+        tr.appendChild(td);
+      });
+      tableBody.appendChild(tr);
+    });
+
+    tableContainer.hidden = false;
+    setTableStatus(`${rows.length} poster visade.`, false);
+  }
+
+  async function loadSchema(tableName) {
+    const res = await fetch(`/admin/advanced/api/schema/${encodeURIComponent(tableName)}`);
+    const data = await res.json();
+    if (!res.ok) {
+      throw new Error(data.message || 'Kunde inte läsa tabellens schema.');
+    }
+    currentSchema = data.schema || [];
+    return currentSchema;
+  }
+
+  async function loadRows(tableName, searchTerm) {
+    const params = new URLSearchParams();
+    if (searchTerm) {
+      params.set('sok', searchTerm);
+    }
+    const res = await fetch(`/admin/advanced/api/rows/${encodeURIComponent(tableName)}?${params.toString()}`);
+    const data = await res.json();
+    if (!res.ok) {
+      throw new Error(data.message || 'Kunde inte läsa poster.');
+    }
+    renderTable(data.rows || []);
+  }
+
+  function parsePayload() {
+    const raw = payloadInput.value.trim();
+    if (!raw) {
+      return {};
+    }
+    try {
+      return JSON.parse(raw);
+    } catch (err) {
+      throw new Error('Ogiltigt JSON-format.');
+    }
+  }
+
+  async function refresh() {
+    const tableName = tableSelect.value;
+    if (!tableName) {
+      setTableStatus('Välj en tabell först.', true);
+      return;
+    }
+    setTableStatus('Laddar…', false);
+    try {
+      await loadSchema(tableName);
+      await loadRows(tableName, searchInput.value.trim());
+    } catch (err) {
+      setTableStatus(err.message, true);
+    }
+  }
+
+  if (tableForm) {
+    tableForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      refresh();
+    });
+  }
+
+  if (createBtn) {
+    createBtn.addEventListener('click', async () => {
+      setEditorMessage('Skapar rad…', false);
+      try {
+        const payload = parsePayload();
+        const tableName = tableSelect.value;
+        const res = await fetch(`/admin/advanced/api/rows/${encodeURIComponent(tableName)}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          throw new Error(data.message || 'Kunde inte skapa rad.');
+        }
+        setEditorMessage('Rad skapad.', false);
+        payloadInput.value = '';
+        await refresh();
+      } catch (err) {
+        setEditorMessage(err.message, true);
+      }
+    });
+  }
+
+  if (updateBtn) {
+    updateBtn.addEventListener('click', async () => {
+      setEditorMessage('Uppdaterar rad…', false);
+      try {
+        const payload = parsePayload();
+        const id = Number(rowIdInput.value);
+        if (!id) {
+          throw new Error('Ange ett giltigt rad-ID.');
+        }
+        const tableName = tableSelect.value;
+        const res = await fetch(`/admin/advanced/api/rows/${encodeURIComponent(tableName)}/${id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          throw new Error(data.message || 'Kunde inte uppdatera rad.');
+        }
+        setEditorMessage('Rad uppdaterad.', false);
+        await refresh();
+      } catch (err) {
+        setEditorMessage(err.message, true);
+      }
+    });
+  }
+
+  if (deleteBtn) {
+    deleteBtn.addEventListener('click', async () => {
+      setEditorMessage('Tar bort rad…', false);
+      try {
+        const id = Number(rowIdInput.value);
+        if (!id) {
+          throw new Error('Ange ett giltigt rad-ID.');
+        }
+        const tableName = tableSelect.value;
+        const res = await fetch(`/admin/advanced/api/rows/${encodeURIComponent(tableName)}/${id}`, {
+          method: 'DELETE'
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          throw new Error(data.message || 'Kunde inte ta bort rad.');
+        }
+        setEditorMessage('Rad borttagen.', false);
+        await refresh();
+      } catch (err) {
+        setEditorMessage(err.message, true);
+      }
+    });
+  }
+
+  if (tableSelect) {
+    tableSelect.addEventListener('change', () => {
+      payloadInput.value = '';
+      rowIdInput.value = '';
+      setEditorMessage('', false);
+      refresh();
+    });
+  }
+
+  if (tableSelect && tableSelect.value) {
+    refresh();
+  }
+})();

--- a/static/js/admin_panel.js
+++ b/static/js/admin_panel.js
@@ -1,0 +1,182 @@
+(function () {
+  const pdfLookupForm = document.getElementById('pdfLookupForm');
+  const pdfLookupMessage = document.getElementById('pdfLookupMessage');
+  const pdfResults = document.getElementById('pdfResults');
+  const pdfResultBody = document.getElementById('pdfResultBody');
+  const resetForm = document.getElementById('resetForm');
+  const resetMessage = document.getElementById('resetMessage');
+  const categories = Array.isArray(window.APP_CATEGORIES) ? window.APP_CATEGORIES : [];
+  let lastLookup = '';
+
+  function setLookupMessage(text, isError) {
+    if (!pdfLookupMessage) return;
+    pdfLookupMessage.textContent = text || '';
+    pdfLookupMessage.classList.toggle('error', Boolean(isError));
+  }
+
+  function renderCategoryOptions(selected) {
+    const select = document.createElement('select');
+    select.multiple = true;
+    select.className = 'category-select';
+    const selectedSet = new Set(selected || []);
+    categories.forEach(([slug, label]) => {
+      const option = document.createElement('option');
+      option.value = slug;
+      option.textContent = label;
+      option.selected = selectedSet.has(slug);
+      select.appendChild(option);
+    });
+    return select;
+  }
+
+  function renderPdfRow(pdf) {
+    const tr = document.createElement('tr');
+    const idCell = document.createElement('td');
+    idCell.textContent = String(pdf.id);
+    tr.appendChild(idCell);
+
+    const fileCell = document.createElement('td');
+    fileCell.textContent = pdf.filename;
+    tr.appendChild(fileCell);
+
+    const categoryCell = document.createElement('td');
+    const select = renderCategoryOptions(pdf.categories);
+    categoryCell.appendChild(select);
+    tr.appendChild(categoryCell);
+
+    const uploadedCell = document.createElement('td');
+    uploadedCell.textContent = pdf.uploaded_at ? new Date(pdf.uploaded_at).toLocaleString('sv-SE') : '';
+    tr.appendChild(uploadedCell);
+
+    const actionsCell = document.createElement('td');
+    const saveBtn = document.createElement('button');
+    saveBtn.type = 'button';
+    saveBtn.textContent = 'Spara kategorier';
+    saveBtn.addEventListener('click', async () => {
+      await updatePdf(pdf.id, Array.from(select.selectedOptions).map((o) => o.value));
+    });
+    const deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
+    deleteBtn.className = 'danger';
+    deleteBtn.textContent = 'Ta bort PDF';
+    deleteBtn.addEventListener('click', async () => {
+      if (!window.confirm('Är du säker på att du vill ta bort PDF:en?')) {
+        return;
+      }
+      await deletePdf(pdf.id);
+    });
+
+    actionsCell.appendChild(saveBtn);
+    actionsCell.appendChild(deleteBtn);
+    tr.appendChild(actionsCell);
+    return tr;
+  }
+
+  async function fetchOverview(personnummer) {
+    setLookupMessage('Hämtar uppgifter…', false);
+    try {
+      const res = await fetch('/admin/api/oversikt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ personnummer })
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.message || 'Kunde inte hämta uppgifter.');
+      }
+      pdfResultBody.innerHTML = '';
+      if (!data.data || !Array.isArray(data.data.pdfs) || data.data.pdfs.length === 0) {
+        setLookupMessage('Inga PDF:er hittades för angivet personnummer.', false);
+        pdfResults.hidden = true;
+        return;
+      }
+      data.data.pdfs.forEach((pdf) => {
+        pdfResultBody.appendChild(renderPdfRow(pdf));
+      });
+      pdfResults.hidden = false;
+      setLookupMessage('PDF:er hämtade.', false);
+    } catch (err) {
+      pdfResults.hidden = true;
+      setLookupMessage(err.message, true);
+    }
+  }
+
+  async function updatePdf(pdfId, newCategories) {
+    setLookupMessage('Sparar kategorier…', false);
+    try {
+      const res = await fetch('/admin/api/uppdatera-pdf', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ personnummer: lastLookup, pdf_id: pdfId, categories: newCategories })
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.message || 'Kunde inte uppdatera PDF.');
+      }
+      setLookupMessage('Kategorier uppdaterade.', false);
+      await fetchOverview(lastLookup);
+    } catch (err) {
+      setLookupMessage(err.message, true);
+    }
+  }
+
+  async function deletePdf(pdfId) {
+    setLookupMessage('Tar bort PDF…', false);
+    try {
+      const res = await fetch('/admin/api/radera-pdf', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ personnummer: lastLookup, pdf_id: pdfId })
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.message || 'Kunde inte ta bort PDF.');
+      }
+      setLookupMessage('PDF borttagen.', false);
+      await fetchOverview(lastLookup);
+    } catch (err) {
+      setLookupMessage(err.message, true);
+    }
+  }
+
+  if (pdfLookupForm) {
+    pdfLookupForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const input = document.getElementById('lookupPersonnummer');
+      if (!input) return;
+      const value = input.value.trim();
+      if (!value) {
+        setLookupMessage('Ange ett personnummer.', true);
+        return;
+      }
+      lastLookup = value;
+      fetchOverview(value);
+    });
+  }
+
+  if (resetForm) {
+    resetForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      if (!resetMessage) return;
+      resetMessage.textContent = 'Skickar återställningslänk…';
+      resetMessage.classList.remove('error');
+      const personnummer = document.getElementById('resetPersonnummer').value.trim();
+      const email = document.getElementById('resetEmail').value.trim();
+      try {
+        const res = await fetch('/admin/api/skicka-aterstallning', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ personnummer, email })
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          throw new Error(data.message || 'Kunde inte skicka återställning.');
+        }
+        resetMessage.textContent = 'Återställningsmejl skickat.';
+      } catch (err) {
+        resetMessage.textContent = err.message;
+        resetMessage.classList.add('error');
+      }
+    });
+  }
+})();

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,60 +1,116 @@
 {% extends 'base.html' %}
-{% block title %}Admin — Skapa användare{% endblock %}
+{% block title %}Admin — Kontrollpanel{% endblock %}
 {% block content %}
-<h1>Admin — Skapa användare</h1>
-<p>Använd detta formulär för att lägga till en väntande användare. Fälten är obligatoriska.</p>
+<h1>Admin — Kontrollpanel</h1>
+<p>Skapa nya användare, hantera intyg och skicka återställningslänkar. Avancerade databasåtgärder finns längst ner på sidan.</p>
 
-<form id="adminForm" autocomplete="off" enctype="multipart/form-data" method="post">
-    <label for="email">E-post</label>
-    <input id="email" name="email" type="email" required placeholder="user@example.com" />
+<section class="panel">
+    <h2>Skapa väntande användare</h2>
+    <p>Använd detta formulär för att registrera en användare och ladda upp intyg.</p>
+    <form id="adminForm" autocomplete="off" enctype="multipart/form-data" method="post">
+        <label for="email">E-post</label>
+        <input id="email" name="email" type="email" required placeholder="user@example.com" />
 
-    <label for="username">Användarnamn</label>
-    <input id="username" name="username" type="text" required placeholder="Fullständigt namn eller användarnamn" />
+        <label for="username">Användarnamn</label>
+        <input id="username" name="username" type="text" required placeholder="Fullständigt namn eller användarnamn" />
 
-    <div class="row">
-        <div class="col">
-            <label for="personnummer">Personnummer</label>
-            <input id="personnummer" name="personnummer" type="text" required placeholder="ÅÅMMDDXXXX" />
-            <small class="hint">Tillåtna format: ÅÅMMDDXXXX eller ÅÅÅÅMMDDXXXX, med eller utan bindestreck.</small>
+        <div class="row">
+            <div class="col">
+                <label for="personnummer">Personnummer</label>
+                <input id="personnummer" name="personnummer" type="text" required placeholder="ÅÅMMDDXXXX" />
+                <small class="hint">Tillåtna format: ÅÅMMDDXXXX eller ÅÅÅÅMMDDXXXX, med eller utan bindestreck.</small>
+            </div>
+
+            <div class="col">
+                <label for="pdf">Ladda upp PDF-filer</label>
+                <input id="pdf" name="pdf" type="file" accept="application/pdf" multiple required />
+                <small class="hint">Endast PDF-filer (max 100 MB totalt).</small>
+            </div>
         </div>
 
-        <div class="col">
-            <label for="pdf">Ladda upp PDF-filer</label>
-            <input id="pdf" name="pdf" type="file" accept="application/pdf" multiple required />
-            <small class="hint">Endast PDF-filer (max 100 MB totalt).</small>
+        <fieldset id="fileCategoryGroup" class="category-group" hidden>
+            <legend>Koppla kategori till varje PDF</legend>
+            <div id="fileCategoryList" class="category-options file-category-list"></div>
+            <small class="hint">Välj en kategori för varje uppladdad PDF.</small>
+        </fieldset>
+
+        <template id="fileCategoryTemplate">
+            <div class="file-category-item">
+                <span class="file-name"></span>
+                <label>
+                    <span class="sr-only">Kategori</span>
+                    <select class="file-category-select" required>
+                        <option value="">Välj kategori</option>
+                        {% for slug, label in categories %}
+                        <option value="{{ slug }}">{{ label }}</option>
+                        {% endfor %}
+                    </select>
+                </label>
+            </div>
+        </template>
+
+        <button id="submitBtn" type="submit">Skapa användare</button>
+
+        <div id="progressContainer" class="progress-container" style="display:none">
+            <div id="progressBar" class="progress-bar"></div>
+            <p class="progress-text">Skapar användare… Detta kan ta upp till 30 sekunder.</p>
         </div>
+
+        <div id="result" class="message" style="display:none"></div>
+    </form>
+</section>
+
+<section class="panel">
+    <h2>Hantera befintliga intyg</h2>
+    <p>Sök fram en användares PDF:er för att ändra kategori eller ta bort filen.</p>
+    <form id="pdfLookupForm" class="inline-form">
+        <label for="lookupPersonnummer">Personnummer</label>
+        <input id="lookupPersonnummer" name="lookupPersonnummer" type="text" required placeholder="ÅÅMMDDXXXX" />
+        <button type="submit">Visa PDF:er</button>
+        <span id="pdfLookupMessage" class="message" aria-live="polite"></span>
+    </form>
+
+    <div id="pdfResults" class="card" hidden>
+        <h3>Intyg</h3>
+        <table>
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Filnamn</th>
+                    <th>Kategorier</th>
+                    <th>Uppladdad</th>
+                    <th>Åtgärder</th>
+                </tr>
+            </thead>
+            <tbody id="pdfResultBody"></tbody>
+        </table>
     </div>
+</section>
 
-    <fieldset id="fileCategoryGroup" class="category-group" hidden>
-        <legend>Koppla kategori till varje PDF</legend>
-        <div id="fileCategoryList" class="category-options file-category-list"></div>
-        <small class="hint">Välj en kategori för varje uppladdad PDF.</small>
-    </fieldset>
+<section class="panel">
+    <h2>Skicka återställningsmejl</h2>
+    <p>Bekräfta användarens uppgifter och skicka en ny länk för att välja lösenord.</p>
+    <form id="resetForm" class="stacked-form">
+        <label for="resetPersonnummer">Personnummer</label>
+        <input id="resetPersonnummer" name="resetPersonnummer" type="text" required placeholder="ÅÅMMDDXXXX" />
 
-    <template id="fileCategoryTemplate">
-        <div class="file-category-item">
-            <span class="file-name"></span>
-            <label>
-                <span class="sr-only">Kategori</span>
-                <select class="file-category-select" required>
-                    <option value="">Välj kategori</option>
-                    {% for slug, label in categories %}
-                    <option value="{{ slug }}">{{ label }}</option>
-                    {% endfor %}
-                </select>
-            </label>
-        </div>
-    </template>
+        <label for="resetEmail">E-post</label>
+        <input id="resetEmail" name="resetEmail" type="email" required placeholder="user@example.com" />
 
-    <button id="submitBtn" type="submit">Skapa användare</button>
+        <button type="submit">Skicka återställningslänk</button>
+        <p id="resetMessage" class="message" aria-live="polite"></p>
+    </form>
+</section>
 
-    <div id="progressContainer" class="progress-container" style="display:none">
-        <div id="progressBar" class="progress-bar"></div>
-        <p class="progress-text">Skapar användare… Detta kan ta upp till 30 sekunder.</p>
-    </div>
-
-    <div id="result" class="message" style="display:none"></div>
-</form>
+<section class="panel">
+    <h2>Avancerade verktyg</h2>
+    <p>Behöver du full åtkomst till databasen? Besök den avancerade redigeraren. Allt loggas.</p>
+    <p><a class="button" href="{{ url_for('admin_advanced') }}">Öppna avancerad databasredigerare</a></p>
+</section>
 
 <script src="{{ url_for('static', filename='js/admin.js') }}"></script>
+<script>
+    window.APP_CATEGORIES = {{ categories|tojson }};
+</script>
+<script src="{{ url_for('static', filename='js/admin_panel.js') }}"></script>
 {% endblock %}

--- a/templates/admin_advanced.html
+++ b/templates/admin_advanced.html
@@ -1,0 +1,55 @@
+{% extends 'base.html' %}
+{% block title %}Admin — Avancerad databasredigerare{% endblock %}
+{% block content %}
+<h1>Avancerad databasredigerare</h1>
+<p>Här kan du läsa, skapa, uppdatera och ta bort poster i databasen. Alla åtgärder loggas tillsammans med din administratörsidentitet.</p>
+
+<section class="panel">
+    <h2>Välj tabell</h2>
+    <form id="tableForm" class="inline-form">
+        <label for="tableSelect">Tabell</label>
+        <select id="tableSelect" name="table">
+            {% for name in tables %}
+            <option value="{{ name }}">{{ name }}</option>
+            {% endfor %}
+        </select>
+
+        <label for="searchInput">Sök</label>
+        <input id="searchInput" name="search" type="text" placeholder="Filtrera poster" />
+
+        <button type="submit">Ladda poster</button>
+    </form>
+</section>
+
+<section class="panel">
+    <h2>Poster</h2>
+    <p id="tableStatus" class="message" aria-live="polite">Välj en tabell för att se poster.</p>
+    <div id="tableContainer" class="responsive-table" hidden>
+        <table>
+            <thead id="tableHead"></thead>
+            <tbody id="tableBody"></tbody>
+        </table>
+    </div>
+</section>
+
+<section class="panel">
+    <h2>Redigera post</h2>
+    <p>Ange fält och värden i JSON-format. Binära kolumner använder Base64-kodning.</p>
+    <form id="editorForm" class="stacked-form">
+        <label for="rowIdInput">Rad-ID</label>
+        <input id="rowIdInput" name="rowId" type="number" min="1" placeholder="ID" />
+
+        <label for="payloadInput">Data (JSON)</label>
+        <textarea id="payloadInput" name="payload" rows="6" placeholder='{"kolumn": "värde"}'></textarea>
+
+        <div class="button-row">
+            <button type="button" id="createBtn">Skapa ny rad</button>
+            <button type="button" id="updateBtn">Uppdatera rad</button>
+            <button type="button" id="deleteBtn" class="danger">Ta bort rad</button>
+        </div>
+        <p id="editorMessage" class="message" aria-live="polite"></p>
+    </form>
+</section>
+
+<script src="{{ url_for('static', filename='js/admin_advanced.js') }}"></script>
+{% endblock %}

--- a/templates/password_reset.html
+++ b/templates/password_reset.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block title %}Återställ lösenord{% endblock %}
+{% block content %}
+<h1>Återställ lösenord</h1>
+{% if invalid %}
+<p class="message error">Länken är inte giltig eller har redan använts. Be en administratör om en ny återställningslänk.</p>
+{% else %}
+<p>Välj ett nytt lösenord. Lösenordet måste bestå av minst åtta tecken.</p>
+<form method="post" class="stacked-form">
+    {% if error %}<p class="message error">{{ error }}</p>{% endif %}
+    <label for="password">Nytt lösenord</label>
+    <input id="password" name="password" type="password" required minlength="8" autocomplete="new-password" />
+
+    <label for="confirm">Bekräfta lösenord</label>
+    <input id="confirm" name="confirm" type="password" required minlength="8" autocomplete="new-password" />
+
+    <button type="submit">Spara nytt lösenord</button>
+</form>
+{% endif %}
+{% endblock %}

--- a/tests/test_admin_panel_features.py
+++ b/tests/test_admin_panel_features.py
@@ -1,0 +1,147 @@
+import json
+
+import app
+import functions
+from course_categories import COURSE_CATEGORIES
+
+
+def _admin_client():
+    client = app.app.test_client()
+    with client.session_transaction() as sess:
+        sess["admin_logged_in"] = True
+        sess["admin_username"] = "testadmin"
+    return client
+
+
+def test_admin_delete_pdf_removes_record(empty_db):
+    engine = empty_db
+    personnummer = "19900101-1234"
+    pnr_norm = functions.normalize_personnummer(personnummer)
+    pnr_hash = functions.hash_value(pnr_norm)
+    first_slug = COURSE_CATEGORIES[0][0]
+    pdf_id = functions.store_pdf_blob(pnr_hash, "test.pdf", b"%PDF", [first_slug])
+    with _admin_client() as client:
+        response = client.post(
+            "/admin/api/radera-pdf",
+            json={"personnummer": personnummer, "pdf_id": pdf_id},
+        )
+    assert response.status_code == 200
+
+    with engine.connect() as conn:
+        result = conn.execute(
+            functions.user_pdfs_table.select().where(
+                functions.user_pdfs_table.c.id == pdf_id
+            )
+        ).first()
+        assert result is None
+        log_entry = conn.execute(
+            functions.admin_audit_log_table.select()
+        ).first()
+        assert log_entry is not None
+        assert log_entry.admin == "testadmin"
+
+
+def test_admin_update_pdf_categories(empty_db):
+    engine = empty_db
+    personnummer = "19900101-1234"
+    pnr_hash = functions.hash_value(functions.normalize_personnummer(personnummer))
+    slugs = [slug for slug, _ in COURSE_CATEGORIES[:2]]
+    pdf_id = functions.store_pdf_blob(pnr_hash, "test.pdf", b"%PDF", [slugs[0]])
+
+    with _admin_client() as client:
+        response = client.post(
+            "/admin/api/uppdatera-pdf",
+            json={
+                "personnummer": personnummer,
+                "pdf_id": pdf_id,
+                "categories": slugs,
+            },
+        )
+    assert response.status_code == 200
+
+    with engine.connect() as conn:
+        result = conn.execute(
+            functions.user_pdfs_table.select().where(
+                functions.user_pdfs_table.c.id == pdf_id
+            )
+        ).first()
+        assert result is not None
+        assert set(result.categories.split(",")) == set(slugs)
+
+
+def test_password_reset_flow(empty_db, monkeypatch):
+    personnummer = "19900101-1234"
+    email = "user@example.com"
+    assert functions.admin_create_user(email, "Användare", personnummer)
+    pnr_hash = functions.hash_value(functions.normalize_personnummer(personnummer))
+    assert functions.user_create_user("GamlaLosen123", pnr_hash)
+
+    captured = {}
+
+    def _fake_send(to_email, link):
+        captured["email"] = to_email
+        captured["link"] = link
+
+    monkeypatch.setattr(app, "send_password_reset_email", _fake_send)
+
+    with _admin_client() as client:
+        response = client.post(
+            "/admin/api/skicka-aterstallning",
+            json={"personnummer": personnummer, "email": email},
+        )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert "link" in data
+    assert captured["link"] == data["link"]
+
+    token = data["link"].rstrip("/").split("/")[-1]
+
+    client = app.app.test_client()
+    reset_response = client.post(
+        f"/aterstall-losenord/{token}",
+        data={"password": "NyLosenord123", "confirm": "NyLosenord123"},
+        follow_redirects=False,
+    )
+    assert reset_response.status_code == 302
+    assert functions.check_personnummer_password(personnummer, "NyLosenord123")
+
+
+def test_admin_advanced_crud(empty_db):
+    engine = empty_db
+    with _admin_client() as client:
+        schema_resp = client.get("/admin/advanced/api/schema/pending_users")
+        assert schema_resp.status_code == 200
+
+        create_payload = {
+            "username": "Avancerad",
+            "email": functions.hash_value("advanced@example.com"),
+            "personnummer": functions.hash_value("199001019999"),
+        }
+        create_resp = client.post(
+            "/admin/advanced/api/rows/pending_users",
+            data=json.dumps(create_payload),
+            content_type="application/json",
+        )
+        assert create_resp.status_code == 201
+        new_id = create_resp.get_json()["row"]["id"]
+
+        update_resp = client.put(
+            f"/admin/advanced/api/rows/pending_users/{new_id}",
+            data=json.dumps({"username": "Uppdaterad"}),
+            content_type="application/json",
+        )
+        assert update_resp.status_code == 200
+
+        rows_resp = client.get("/admin/advanced/api/rows/pending_users")
+        assert rows_resp.status_code == 200
+        rows = rows_resp.get_json()["rows"]
+        assert any(row["id"] == new_id for row in rows)
+
+        delete_resp = client.delete(
+            f"/admin/advanced/api/rows/pending_users/{new_id}"
+        )
+        assert delete_resp.status_code == 200
+
+    with engine.connect() as conn:
+        log_rows = list(conn.execute(functions.admin_audit_log_table.select()))
+        assert len(log_rows) >= 3


### PR DESCRIPTION
## Summary
- expand the adminpanel with verktyg för att hantera PDF-intyg, uppdatera kategorier och skicka lösenordsåterställningar
- lägga till en avancerad databasredigerare med CRUD-API, revisionsloggar och komplett webgränssnitt
- införa ny lösenordsåterställningsprocess med e-postlänk, tokenhantering och vy för användare samt tillhörande tester

## Testing
- pytest

![Adminpanel](browser:/invocations/tpjqpzcr/artifacts/artifacts/admin-panel.png)

------
https://chatgpt.com/codex/tasks/task_e_68dacfd63304832dade0762f348c89e1