### PR TITLE
Improve admin PDF category editor UI

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -378,6 +378,23 @@ footer {
     margin-top: 0;
 }
 
+.card {
+    margin-top: 1.5rem;
+    padding: 1.5rem;
+    background: #fff;
+    border: 1px solid #d4dae2;
+    border-radius: 10px;
+    box-shadow: 0 12px 30px rgba(15, 31, 51, 0.08);
+}
+
+.card h3 {
+    margin-top: 0;
+}
+
+.table-scroll {
+    overflow-x: auto;
+}
+
 .inline-form {
     display: flex;
     flex-wrap: wrap;
@@ -448,7 +465,16 @@ button.danger:focus {
 }
 
 .category-select {
-    min-width: 180px;
+    min-width: 200px;
+    min-height: 7rem;
+    padding: 6px;
+}
+
+.category-empty {
+    display: inline-block;
+    padding: 0.4rem 0.5rem;
+    color: #5f6b7a;
+    font-style: italic;
 }
 
 .button-row {

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -72,18 +72,20 @@
 
     <div id="pdfResults" class="card" hidden>
         <h3>Intyg</h3>
-        <table>
-            <thead>
-                <tr>
-                    <th>ID</th>
-                    <th>Filnamn</th>
-                    <th>Kategorier</th>
-                    <th>Uppladdad</th>
-                    <th>Åtgärder</th>
-                </tr>
-            </thead>
-            <tbody id="pdfResultBody"></tbody>
-        </table>
+        <div class="table-scroll">
+            <table>
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Filnamn</th>
+                        <th>Kategorier</th>
+                        <th>Uppladdad</th>
+                        <th>Åtgärder</th>
+                    </tr>
+                </thead>
+                <tbody id="pdfResultBody"></tbody>
+            </table>
+        </div>
     </div>
 </section>
 


### PR DESCRIPTION
## Summary
- normalise and reuse server-provided kurskategorier so the redigerare always shows options
- add disabled state and tom-lista text when no categories exist and improve multi-select sizing
- restyle the PDF-resultatkort with padding and scroll container to fix the layout regression

## Testing
- `pytest`

## Screenshots
![Adminpanelen med fungerande kategorival](browser:/invocations/cnxiwnda/artifacts/artifacts/admin-page.png)


------
https://chatgpt.com/codex/tasks/task_e_68dad64ed720832d85665f2da1cc93ac