### PR TITLE
Move share selection UI into floating popup

### DIFF
--- a/app.py
+++ b/app.py
@@ -297,29 +297,33 @@ def send_creation_email(to_email: str, link: str) -> None:
 
 def send_pdf_share_email(
     recipient_email: str,
-    pdf_filename: str,
-    pdf_content: bytes,
+    attachments: Sequence[tuple[str, bytes]],
     sender_name: str,
 ) -> None:
-    # Send the selected PDF as an attachment to ``recipient_email``.
+    # Send one or more PDFs as attachments to ``recipient_email``.
+
+    if not attachments:
+        raise ValueError("Minst ett intyg krävs för delning.")
 
     normalized_email = _normalize_valid_email(recipient_email)
     settings = _load_smtp_settings()
 
     safe_sender = escape(sender_name.strip() or "En användare")
-    safe_filename = escape(pdf_filename)
 
     msg = EmailMessage(policy=policy.SMTP.clone(max_line_length=1000))
-    msg["Subject"] = f"Delat intyg från {safe_sender}"
+    subject_prefix = "Delade" if len(attachments) > 1 else "Delat"
+    msg["Subject"] = f"{subject_prefix} intyg från {safe_sender}"
     msg["From"] = settings.user
     msg["To"] = normalized_email
     msg["Message-ID"] = make_msgid()
     msg["Date"] = format_datetime(datetime.now(timezone.utc))
-    msg.set_content(
-        (
+
+    if len(attachments) == 1:
+        safe_filename = escape(attachments[0][0])
+        body_html = (
             "<html>"
             "<body style='font-family: Arial, sans-serif; line-height: 1.5;'>"
-            f"<p>Hej,</p>"
+            "<p>Hej,</p>"
             f"<p><strong>{safe_sender}</strong> har delat ett intyg med dig via JK "
             "Utbildningsintyg.</p>"
             f"<p>Intyget hittar du i bilagan med filnamnet <em>{safe_filename}</em>."
@@ -327,15 +331,33 @@ def send_pdf_share_email(
             "<p>Har du inte begärt detta intyg kan du ignorera detta e-postmeddelande.</p>"
             "</body>"
             "</html>"
-        ),
-        subtype="html",
-    )
-    msg.add_attachment(
-        pdf_content,
-        maintype="application",
-        subtype="pdf",
-        filename=pdf_filename,
-    )
+        )
+    else:
+        item_list = "".join(
+            f"<li><em>{escape(filename)}</em></li>" for filename, _ in attachments
+        )
+        body_html = (
+            "<html>"
+            "<body style='font-family: Arial, sans-serif; line-height: 1.5;'>"
+            "<p>Hej,</p>"
+            f"<p><strong>{safe_sender}</strong> har delat flera intyg med dig via JK "
+            "Utbildningsintyg.</p>"
+            "<p>Intygen hittar du i följande bilagor:</p>"
+            f"<ul>{item_list}</ul>"
+            "<p>Har du inte begärt dessa intyg kan du ignorera detta e-postmeddelande.</p>"
+            "</body>"
+            "</html>"
+        )
+
+    msg.set_content(body_html, subtype="html")
+
+    for filename, content in attachments:
+        msg.add_attachment(
+            content,
+            maintype="application",
+            subtype="pdf",
+            filename=filename,
+        )
 
     _send_email_message(msg, normalized_email, settings)
 
@@ -570,13 +592,38 @@ def share_pdf() -> tuple[Response, int]:
     if not payload:
         return jsonify({'fel': 'Ogiltig begäran.'}), 400
 
-    pdf_id_raw = payload.get('pdf_id') if hasattr(payload, 'get') else None
+    pdf_ids_raw = payload.get('pdf_ids') if hasattr(payload, 'get') else None
     recipient_email = (payload.get('recipient_email', '') if hasattr(payload, 'get') else '').strip()
 
-    try:
-        pdf_id = int(pdf_id_raw)
-    except (TypeError, ValueError):
-        logger.warning("Invalid pdf_id provided for sharing: %r", pdf_id_raw)
+    if pdf_ids_raw is None and hasattr(payload, 'get'):
+        pdf_id_raw = payload.get('pdf_id')
+        if pdf_id_raw is not None:
+            pdf_ids_raw = [pdf_id_raw]
+
+    if pdf_ids_raw is None:
+        return jsonify({'fel': 'Ogiltigt intyg angivet.'}), 400
+
+    if isinstance(pdf_ids_raw, (str, bytes)):
+        candidate_ids = [pdf_ids_raw]
+    elif isinstance(pdf_ids_raw, (list, tuple, set)):
+        candidate_ids = list(pdf_ids_raw)
+    else:
+        candidate_ids = [pdf_ids_raw]
+
+    pdf_ids: list[int] = []
+    seen_ids: set[int] = set()
+    for raw_id in candidate_ids:
+        try:
+            pdf_id = int(raw_id)
+        except (TypeError, ValueError):
+            logger.warning("Invalid pdf_id provided for sharing: %r", raw_id)
+            return jsonify({'fel': 'Ogiltigt intyg angivet.'}), 400
+        if pdf_id in seen_ids:
+            continue
+        seen_ids.add(pdf_id)
+        pdf_ids.append(pdf_id)
+
+    if not pdf_ids:
         return jsonify({'fel': 'Ogiltigt intyg angivet.'}), 400
 
     if not recipient_email:
@@ -587,12 +634,15 @@ def share_pdf() -> tuple[Response, int]:
         logger.error("Share request missing personnummer in session")
         return jsonify({'fel': 'Saknar användaruppgifter.'}), 400
 
-    pdf = functions.get_pdf_content(pnr_hash, pdf_id)
-    if not pdf:
-        logger.warning("PDF %s not found for user %s when sharing", pdf_id, pnr_hash)
-        return jsonify({'fel': 'Intyget kunde inte hittas.'}), 404
+    attachments: list[tuple[str, bytes]] = []
 
-    filename, content = pdf
+    for pdf_id in pdf_ids:
+        pdf = functions.get_pdf_content(pnr_hash, pdf_id)
+        if not pdf:
+            logger.warning("PDF %s not found for user %s when sharing", pdf_id, pnr_hash)
+            return jsonify({'fel': 'Intyget kunde inte hittas.'}), 404
+        filename, content = pdf
+        attachments.append((filename, content))
 
     sender_name = session.get('username')
     if not sender_name:
@@ -617,23 +667,30 @@ def share_pdf() -> tuple[Response, int]:
     try:
         send_pdf_share_email(
             normalized_recipient,
-            filename,
-            content,
+            attachments,
             sender_display,
         )
     except RuntimeError as exc:
         logger.exception(
-            "Failed to share pdf %s from %s to %s", pdf_id, pnr_hash, normalized_recipient
+            "Failed to share pdf %s from %s to %s",
+            pdf_ids,
+            pnr_hash,
+            normalized_recipient,
         )
         return jsonify({'fel': 'Ett internt fel har inträffat.'}), 500
 
     logger.info(
         "User %s delade intyg %s med %s",
         pnr_hash,
-        pdf_id,
+        pdf_ids,
         normalized_recipient,
     )
-    return jsonify({'meddelande': 'Intyget har skickats via e-post.'}), 200
+    success_message = (
+        'Intyget har skickats via e-post.'
+        if len(attachments) == 1
+        else 'Intygen har skickats via e-post.'
+    )
+    return jsonify({'meddelande': success_message}), 200
 
 
 @app.route('/view_pdf/<int:pdf_id>')

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -268,6 +268,131 @@
     box-shadow: none;
 }
 
+.share-selected-button {
+    background-color: #1d4ed8;
+    color: #ffffff;
+    border: none;
+    border-radius: 10px;
+    padding: 10px 18px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.share-selected-button:hover {
+    background-color: #153e9b;
+    box-shadow: 0 12px 22px rgba(29, 78, 216, 0.25);
+    transform: translateY(-1px);
+}
+
+.share-selected-button:focus-visible {
+    outline: 3px solid rgba(59, 130, 246, 0.55);
+    outline-offset: 2px;
+}
+
+.share-selected-button:disabled {
+    background-color: #9ca3af;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.share-selection-popup {
+    position: fixed;
+    right: 24px;
+    bottom: 24px;
+    width: min(340px, calc(100% - 32px));
+    z-index: 2000;
+    pointer-events: none;
+}
+
+.share-selection-popup[hidden] {
+    display: none;
+}
+
+.share-selection-popup.is-visible .share-selection-popup__inner {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.share-selection-popup__inner {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 18px 20px 20px;
+    border-radius: 16px;
+    background: linear-gradient(180deg, #ffffff 0%, #f9fafb 100%);
+    box-shadow: 0 24px 40px rgba(15, 23, 42, 0.18);
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    opacity: 0;
+    transform: translateY(12px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    pointer-events: auto;
+}
+
+.share-selection-popup__close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: transparent;
+    border: none;
+    font-size: 1.3rem;
+    line-height: 1;
+    cursor: pointer;
+    color: #475569;
+}
+
+.share-selection-popup__close:hover,
+.share-selection-popup__close:focus-visible {
+    color: #1d4ed8;
+}
+
+.share-selection-popup__close:focus-visible {
+    outline: 3px solid rgba(59, 130, 246, 0.55);
+    border-radius: 50%;
+}
+
+.share-selection-popup__hint {
+    margin: 0;
+    padding-right: 22px;
+    font-size: 0.95rem;
+    color: #334155;
+    line-height: 1.4;
+}
+
+.share-selection-popup .share-selected-button {
+    align-self: flex-start;
+}
+
+.pdf-entry {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.pdf-select {
+    width: 18px;
+    height: 18px;
+    margin: 4px 0 0;
+    accent-color: #1d4ed8;
+    flex-shrink: 0;
+}
+
+.pdf-details {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.pdf-actions {
+    margin-top: 0;
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
 .share-modal {
     position: fixed;
     inset: 0;
@@ -396,6 +521,30 @@
 
 .share-modal__feedback[data-state="info"] {
     color: #2563eb;
+}
+
+.share-modal__selection {
+    border: 1px solid #e5e7eb;
+    border-radius: 10px;
+    background: #f3f4f6;
+    padding: 12px 14px;
+}
+
+.share-modal__selection[hidden] {
+    display: none;
+}
+
+.share-modal__selection-lead {
+    margin: 0 0 8px;
+    font-size: 0.9rem;
+    color: #374151;
+}
+
+#shareDocumentList {
+    margin: 0;
+    padding-left: 18px;
+    font-size: 0.9rem;
+    color: #1f2937;
 }
 
 @media (max-width: 640px) {

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -56,20 +56,33 @@
     const shareForm = document.getElementById('shareForm');
     const shareEmailInput = document.getElementById('shareRecipientEmail');
     const shareFeedback = document.getElementById('shareFeedback');
-    const shareDocumentName = document.getElementById('shareDocumentName');
+    const shareDocumentSummary = document.getElementById('shareDocumentSummary');
+    const shareDocumentSelection = document.getElementById('shareDocumentSelection');
+    const shareDocumentList = document.getElementById('shareDocumentList');
     const closeElements = shareModal
       ? Array.from(shareModal.querySelectorAll('[data-share-close]'))
       : [];
     const submitButton = shareForm
       ? shareForm.querySelector('button[type="submit"]')
       : null;
+    const shareSelectedButton = document.getElementById('shareSelectedButton');
+    const shareSelectionPopup = document.getElementById('shareSelectionPopup');
+    const shareSelectionClose = shareSelectionPopup
+      ? shareSelectionPopup.querySelector('[data-share-selection-close]')
+      : null;
+    const selectionCheckboxes = Array.from(
+      document.querySelectorAll('[data-share-select]')
+    );
 
     if (!shareModal || !shareForm || !shareEmailInput || !submitButton) {
       return;
     }
 
-    let activePdfId = null;
+    let activePdfIds = [];
+    let clearSelectionOnSuccess = false;
     let isSubmitting = false;
+    let shareSelectionDismissed = false;
+    let shareSelectionHideTimeout;
 
     function setFeedback(message, state) {
       if (!shareFeedback) {
@@ -95,25 +108,112 @@
       }
     };
 
-    function openShareModal(pdfId, pdfName) {
-      activePdfId = pdfId;
+    function renderSelectionList(items) {
+      if (!shareDocumentSelection || !shareDocumentList) {
+        return;
+      }
+
+      shareDocumentList.innerHTML = '';
+
+      if (!items.length) {
+        shareDocumentSelection.hidden = true;
+        return;
+      }
+
+      const fragment = document.createDocumentFragment();
+      items.forEach((item) => {
+        const listItem = document.createElement('li');
+        listItem.textContent = item.name || 'intyget';
+        fragment.appendChild(listItem);
+      });
+
+      shareDocumentList.appendChild(fragment);
+      shareDocumentSelection.hidden = false;
+    }
+
+    function showShareSelectionPopup() {
+      if (!shareSelectionPopup) {
+        return;
+      }
+
+      if (shareSelectionHideTimeout) {
+        window.clearTimeout(shareSelectionHideTimeout);
+        shareSelectionHideTimeout = undefined;
+      }
+
+      shareSelectionPopup.hidden = false;
+      shareSelectionPopup.setAttribute('aria-hidden', 'false');
+      requestAnimationFrame(() => {
+        shareSelectionPopup.classList.add('is-visible');
+      });
+    }
+
+    function hideShareSelectionPopup({ dismiss = false, resetDismissal = false } = {}) {
+      if (!shareSelectionPopup) {
+        return;
+      }
+
+      if (shareSelectionHideTimeout) {
+        window.clearTimeout(shareSelectionHideTimeout);
+        shareSelectionHideTimeout = undefined;
+      }
+
+      if (dismiss) {
+        shareSelectionDismissed = true;
+      }
+
+      if (resetDismissal) {
+        shareSelectionDismissed = false;
+      }
+
+      shareSelectionPopup.classList.remove('is-visible');
+      shareSelectionPopup.setAttribute('aria-hidden', 'true');
+      shareSelectionHideTimeout = window.setTimeout(() => {
+        shareSelectionPopup.hidden = true;
+        shareSelectionHideTimeout = undefined;
+      }, 200);
+    }
+
+    function openShareModal(pdfs, { clearSelection = false } = {}) {
+      activePdfIds = pdfs.map((pdf) => pdf.id);
+      clearSelectionOnSuccess = clearSelection;
       shareModal.classList.add('is-visible');
       shareModal.setAttribute('aria-hidden', 'false');
       setFeedback('', '');
       shareEmailInput.value = '';
       shareEmailInput.focus();
-      if (shareDocumentName) {
-        shareDocumentName.textContent = pdfName || 'intyget';
+      if (shareDocumentSummary) {
+        if (pdfs.length === 1) {
+          shareDocumentSummary.textContent = pdfs[0].name || 'intyget';
+        } else if (pdfs.length > 1) {
+          shareDocumentSummary.textContent = `${pdfs.length} intyg`;
+        } else {
+          shareDocumentSummary.textContent = 'intyget';
+        }
       }
+      renderSelectionList(pdfs);
       document.addEventListener('keydown', handleKeyDown);
+      hideShareSelectionPopup();
     }
 
     function closeShareModal() {
-      activePdfId = null;
+      activePdfIds = [];
+      clearSelectionOnSuccess = false;
       shareModal.classList.remove('is-visible');
       shareModal.setAttribute('aria-hidden', 'true');
       setFeedback('', '');
+      if (shareDocumentSummary) {
+        shareDocumentSummary.textContent = 'intyget';
+      }
+      renderSelectionList([]);
       document.removeEventListener('keydown', handleKeyDown);
+      if (
+        shareSelectionPopup &&
+        getSelectedPdfs().length > 0 &&
+        !shareSelectionDismissed
+      ) {
+        showShareSelectionPopup();
+      }
     }
 
     closeElements.forEach((element) => {
@@ -136,14 +236,18 @@
         return;
       }
 
-      if (!activePdfId) {
+      if (!activePdfIds.length) {
         setFeedback('Det gick inte att identifiera intyget.', 'error');
         return;
       }
 
       isSubmitting = true;
       submitButton.disabled = true;
-      setFeedback('Skickar intyget...', 'info');
+      const sendingMessage =
+        activePdfIds.length === 1
+          ? 'Skickar intyget...'
+          : 'Skickar intygen...';
+      setFeedback(sendingMessage, 'info');
 
       try {
         const response = await fetch('/share_pdf', {
@@ -153,7 +257,7 @@
             Accept: 'application/json',
           },
           body: JSON.stringify({
-            pdf_id: activePdfId,
+            pdf_ids: activePdfIds,
             recipient_email: email,
           }),
         });
@@ -161,11 +265,18 @@
         const data = await response.json().catch(() => ({}));
 
         if (response.ok) {
-          setFeedback(
-            data.meddelande || 'Intyget har skickats.',
-            'success'
-          );
+          const defaultSuccess =
+            activePdfIds.length === 1
+              ? 'Intyget har skickats.'
+              : 'Intygen har skickats.';
+          setFeedback(data.meddelande || defaultSuccess, 'success');
           shareEmailInput.value = '';
+          if (clearSelectionOnSuccess) {
+            selectionCheckboxes.forEach((checkbox) => {
+              checkbox.checked = false;
+            });
+            updateShareSelectionState();
+          }
         } else {
           setFeedback(
             data.fel || 'Det gick inte att skicka intyget.',
@@ -179,6 +290,66 @@
         submitButton.disabled = false;
       }
     });
+
+    function getSelectedPdfs() {
+      return selectionCheckboxes
+        .filter((checkbox) => checkbox.checked)
+        .map((checkbox) => ({
+          id: Number.parseInt(checkbox.value || '', 10),
+          name: checkbox.dataset.pdfName || 'intyget',
+        }))
+        .filter((pdf) => Number.isInteger(pdf.id));
+    }
+
+    function updateShareSelectionState() {
+      if (!shareSelectedButton) {
+        return;
+      }
+
+      const selected = getSelectedPdfs();
+      shareSelectedButton.disabled = selected.length === 0;
+
+      if (selected.length === 1) {
+        shareSelectedButton.textContent = 'Dela markerat intyg';
+      } else if (selected.length > 1) {
+        shareSelectedButton.textContent = `Dela ${selected.length} markerade intyg`;
+      } else {
+        shareSelectedButton.textContent = 'Dela markerade intyg';
+      }
+
+      if (!shareSelectionPopup) {
+        return;
+      }
+
+      if (selected.length === 0) {
+        hideShareSelectionPopup({ resetDismissal: true });
+      } else if (!shareSelectionDismissed) {
+        showShareSelectionPopup();
+      }
+    }
+
+    selectionCheckboxes.forEach((checkbox) => {
+      checkbox.addEventListener('change', updateShareSelectionState);
+    });
+
+    updateShareSelectionState();
+
+    if (shareSelectedButton) {
+      shareSelectedButton.addEventListener('click', () => {
+        const selected = getSelectedPdfs();
+        if (!selected.length) {
+          return;
+        }
+
+        openShareModal(selected, { clearSelection: true });
+      });
+    }
+
+    if (shareSelectionClose) {
+      shareSelectionClose.addEventListener('click', () => {
+        hideShareSelectionPopup({ dismiss: true });
+      });
+    }
 
     const shareButtons = Array.from(
       document.querySelectorAll('[data-share-button]')
@@ -194,7 +365,7 @@
           return;
         }
 
-        openShareModal(pdfId, pdfName);
+        openShareModal([{ id: pdfId, name: pdfName }]);
       });
     });
   }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -41,29 +41,41 @@
             <ul class="pdf-list">
                 {% for pdf in group.pdfs %}
                 <li data-pdf-categories="{{ pdf.categories | join(',') }}">
-                    <a href="{{ url_for('download_pdf', pdf_id=pdf.id) }}" download>
-                        {{ pdf.filename }}
-                    </a>
-                    <span class="pdf-meta">
-                        <strong>Kategorier:</strong>
-                        {% if pdf.category_labels %}
-                            {{ pdf.category_labels | join(', ') }}
-                        {% else %}
-                            Inte angiven
-                        {% endif %}
-                        <br>
-
-                    </span>
-                    <div class="pdf-actions">
-                        <button
-                            type="button"
-                            class="share-button"
-                            data-share-button
-                            data-pdf-id="{{ pdf.id }}"
+                    <div class="pdf-entry">
+                        <input
+                            type="checkbox"
+                            class="pdf-select"
+                            data-share-select
+                            value="{{ pdf.id }}"
                             data-pdf-name="{{ pdf.filename }}"
+                            aria-label="Markera {{ pdf.filename }} för delning"
                         >
-                            Dela via e-post
-                        </button>
+                        <div class="pdf-details">
+                            <a href="{{ url_for('download_pdf', pdf_id=pdf.id) }}" download>
+                                {{ pdf.filename }}
+                            </a>
+                            <span class="pdf-meta">
+                                <strong>Kategorier:</strong>
+                                {% if pdf.category_labels %}
+                                    {{ pdf.category_labels | join(', ') }}
+                                {% else %}
+                                    Inte angiven
+                                {% endif %}
+                                <br>
+
+                            </span>
+                        </div>
+                        <div class="pdf-actions">
+                            <button
+                                type="button"
+                                class="share-button"
+                                data-share-button
+                                data-pdf-id="{{ pdf.id }}"
+                                data-pdf-name="{{ pdf.filename }}"
+                            >
+                                Dela via e-post
+                            </button>
+                        </div>
                     </div>
                 </li>
                 {% endfor %}
@@ -76,14 +88,48 @@
     {% endif %}
 </section>
 
+{% if grouped_pdfs %}
+<div
+    id="shareSelectionPopup"
+    class="share-selection-popup"
+    aria-live="polite"
+    aria-hidden="true"
+    hidden
+>
+    <div class="share-selection-popup__inner">
+        <button
+            type="button"
+            class="share-selection-popup__close"
+            aria-label="Stäng delningsrutan"
+            data-share-selection-close
+        >&times;</button>
+        <p class="share-selection-popup__hint">
+            Markera de intyg du vill dela och klicka på knappen för att skicka dem i samma e-post.
+        </p>
+        <button
+            type="button"
+            id="shareSelectedButton"
+            class="share-selected-button"
+            disabled
+        >
+            Dela markerade intyg
+        </button>
+    </div>
+</div>
+{% endif %}
+
 <div id="shareModal" class="share-modal" aria-hidden="true">
     <div class="share-modal__backdrop" data-share-close></div>
     <div class="share-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="shareModalTitle">
         <button type="button" class="share-modal__close" aria-label="Stäng delningsrutan" data-share-close>&times;</button>
         <h2 id="shareModalTitle">Dela intyg via e-post</h2>
         <p class="share-modal__lead">
-            Du delar <strong id="shareDocumentName">intyget</strong>. Ange mottagarens e-postadress nedan.
+            Du delar <strong id="shareDocumentSummary">intyget</strong>. Ange mottagarens e-postadress nedan.
         </p>
+        <div class="share-modal__selection" id="shareDocumentSelection" hidden>
+            <p class="share-modal__selection-lead">Följande intyg skickas som bilagor:</p>
+            <ul id="shareDocumentList"></ul>
+        </div>
         <form id="shareForm" class="share-form" novalidate>
             <label for="shareRecipientEmail">Mottagarens e-postadress</label>
             <input

--- a/tests/test_share_pdf.py
+++ b/tests/test_share_pdf.py
@@ -13,11 +13,11 @@ def _login_default_user(client):
     )
 
 
-def _store_sample_pdf() -> int:
+def _store_sample_pdf(filename: str = "delningstest.pdf") -> int:
     personnummer_hash = functions.hash_value("9001011234")
     return functions.store_pdf_blob(
         personnummer_hash,
-        "delningstest.pdf",
+        filename,
         b"%PDF-1.4 sample",
         [COURSE_CATEGORIES[0][0]],
     )
@@ -61,7 +61,7 @@ def test_share_pdf_sends_email(monkeypatch, user_db):
         response = client.post(
             "/share_pdf",
             json={
-                "pdf_id": pdf_id,
+                "pdf_ids": [pdf_id],
                 "recipient_email": "mottagare@example.com",
             },
         )
@@ -79,7 +79,7 @@ def test_share_pdf_sends_email(monkeypatch, user_db):
 
     html_part = message.get_body(preferencelist=("html", "plain"))
     assert html_part is not None
-    assert "Test" in html_part.get_content()
+    assert "delat ett intyg" in html_part.get_content()
 
     attachments = list(message.iter_attachments())
     assert len(attachments) == 1
@@ -98,7 +98,7 @@ def test_share_pdf_rejects_invalid_email(monkeypatch, user_db):
         _login_default_user(client)
         response = client.post(
             "/share_pdf",
-            json={"pdf_id": pdf_id, "recipient_email": "fel-adress"},
+            json={"pdf_ids": [pdf_id], "recipient_email": "fel-adress"},
         )
 
     assert response.status_code == 400
@@ -114,9 +114,53 @@ def test_share_pdf_missing_document(monkeypatch, user_db):
         _login_default_user(client)
         response = client.post(
             "/share_pdf",
-            json={"pdf_id": 9999, "recipient_email": "mottagare@example.com"},
+            json={"pdf_ids": [9999], "recipient_email": "mottagare@example.com"},
         )
 
     assert response.status_code == 404
     data = response.get_json()
     assert "kunde inte hittas" in data["fel"]
+
+
+def test_share_multiple_pdfs(monkeypatch, user_db):
+    _set_mail_env(monkeypatch)
+    first_pdf = _store_sample_pdf("delningstest.pdf")
+    second_pdf = _store_sample_pdf("extra-intyg.pdf")
+
+    sent = {}
+
+    def fake_sender(message, recipient, settings):
+        sent["message"] = message
+        sent["recipient"] = recipient
+        sent["settings"] = settings
+
+    monkeypatch.setattr(app, "_send_email_message", fake_sender)
+
+    with app.app.test_client() as client:
+        _login_default_user(client)
+        response = client.post(
+            "/share_pdf",
+            json={
+                "pdf_ids": [first_pdf, second_pdf],
+                "recipient_email": "mottagare@example.com",
+            },
+        )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["meddelande"] == "Intygen har skickats via e-post."
+
+    assert sent["recipient"] == "mottagare@example.com"
+    message = sent["message"]
+    assert message["Subject"].startswith("Delade intyg")
+
+    html_part = message.get_body(preferencelist=("html", "plain"))
+    assert html_part is not None
+    html_content = html_part.get_content()
+    assert "flera intyg" in html_content
+    assert "delningstest.pdf" in html_content
+    assert "extra-intyg.pdf" in html_content
+
+    attachments = list(message.iter_attachments())
+    filenames = {attachment.get_filename() for attachment in attachments}
+    assert filenames == {"delningstest.pdf", "extra-intyg.pdf"}


### PR DESCRIPTION
## Summary
- flytta rutan för att dela flera intyg till en fristående popup som visas när intyg har markerats
- uppdatera JavaScriptet för att visa, dölja och återställa popupen beroende på valda intyg samt tillåta att den stängs manuellt
- lägga till nya stilar för popupen och förbättra tillgänglighetsattribut
- kunde tyvärr inte bifoga skärmdump eftersom applikationen kräver databasuppgifter som saknas i testmiljön

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dad4e4a814832d913f7d11933caa31