### PR TITLE
Move certificate sharing inputs into a modal popup

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -344,22 +344,40 @@
 }
 
 .share-modal {
+    border: none;
+    padding: 0;
+    margin: 0;
+    background: transparent;
+}
+
+.share-modal::backdrop {
+    background: rgba(15, 23, 42, 0.45);
+}
+
+.share-modal[data-polyfill="true"] {
     position: fixed;
     inset: 0;
     display: none;
     align-items: center;
     justify-content: center;
     z-index: 1000;
+    background: transparent;
 }
 
-.share-modal.is-visible {
-    display: flex;
-}
-
-.share-modal__backdrop {
+.share-modal[data-polyfill="true"]::before {
+    content: "";
     position: absolute;
     inset: 0;
     background: rgba(15, 23, 42, 0.45);
+}
+
+.share-modal[data-polyfill="true"].is-visible {
+    display: flex;
+}
+
+.share-modal[data-polyfill="true"] .share-modal__dialog {
+    position: relative;
+    z-index: 1;
 }
 
 .share-modal__dialog {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -102,9 +102,8 @@
     {% endif %}
 </section>
 
-<div id="shareModal" class="share-modal" aria-hidden="true">
-    <div class="share-modal__backdrop" data-share-close></div>
-    <div class="share-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="shareModalTitle">
+<dialog id="shareModal" class="share-modal" aria-modal="true" aria-labelledby="shareModalTitle">
+    <div class="share-modal__dialog" role="document">
         <button type="button" class="share-modal__close" aria-label="Stäng delningsrutan" data-share-close>&times;</button>
         <h2 id="shareModalTitle">Dela intyg via e-post</h2>
         <p class="share-modal__lead">
@@ -128,6 +127,6 @@
         </form>
         <p class="share-modal__feedback" id="shareFeedback" role="alert" hidden></p>
     </div>
-</div>
+</dialog>
 <script src="{{ url_for('static', filename='js/dashboard.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace the dashboard share markup with a `<dialog>`-based modal so the e-postformulär öppnas som en popup
- update the dashboard JavaScript to drive the native dialog API with a keyboard-friendly fallback
- adjust the dashboard styles to style the dialog backdrop and a lightweight polyfill mode

## Testing
- pytest

## Screenshots
![Delningsmodalen med e-postfältet](browser:/invocations/isrhyozk/artifacts/artifacts/dashboard-share-modal.png)

------
https://chatgpt.com/codex/tasks/task_e_68dada8950e4832d9a9c760730541ae7