### PR TITLE
Move dashboard data removal request link to subtle corner button

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -20,6 +20,23 @@
     align-items: flex-start;
 }
 
+.support-actions--floating {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    margin: 0;
+    gap: 8px;
+    align-items: flex-end;
+    z-index: 30;
+}
+
+@media (max-width: 768px) {
+    .support-actions--floating {
+        bottom: 16px;
+        right: 16px;
+    }
+}
+
 .support-text {
     margin: 0;
     font-size: 1rem;
@@ -40,6 +57,32 @@
     border: 1px solid #d1d5db;
     transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
     box-shadow: none;
+}
+
+.support-email-button--corner {
+    padding: 8px 12px;
+    border-radius: 9999px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    background: rgba(243, 244, 246, 0.9);
+    border-color: transparent;
+    box-shadow: 0 10px 22px rgba(15, 23, 42, 0.12);
+    color: #374151;
+    backdrop-filter: blur(6px);
+}
+
+.support-email-button--corner:hover,
+.support-email-button--corner:focus {
+    background: rgba(229, 231, 235, 0.95);
+    color: #111827;
+}
+
+.support-email-button__icon {
+    font-size: 1rem;
+}
+
+.support-email-button__text {
+    white-space: nowrap;
 }
 
 .support-email-button:hover,

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -12,10 +12,6 @@
             Hej! Här är dina intyg.
         {% endif %}
     </h1>
-    <div class="support-actions" aria-label="Sektion för att kontakta supporten">
-        <p class="support-text">Behöver du radera dina uppgifter? Kontakta oss så hjälper vi dig.</p>
-        <a class="support-email-button" href="mailto:support@utbildningsintyg.se?subject=Beg%C3%A4ran%20om%20radering%20av%20anv%C3%A4ndardata&body=Hej%20supportteamet%2C%0A%0AJag%20vill%20beg%C3%A4ra%20att%20all%20min%20anv%C3%A4ndardata%20tas%20bort.%0A%0AV%C3%A4nligen%20bekr%C3%A4fta%20n%C3%A4r%20det%20%C3%A4r%20klart.%0A%0ATack!">Begär radering av mina uppgifter</a>
-    </div>
     {% if category_summary %}
     <section class="category-list" aria-label="Tillgängliga kurskategorier">
         <h2>Kurskategorier</h2>
@@ -101,6 +97,18 @@
     <p>Inga PDF:er uppladdade.</p>
     {% endif %}
 </section>
+
+<div class="support-actions support-actions--floating" aria-label="Sektion för att kontakta supporten">
+    <a
+        class="support-email-button support-email-button--corner"
+        href="mailto:support@utbildningsintyg.se?subject=Beg%C3%A4ran%20om%20radering%20av%20anv%C3%A4ndardata&body=Hej%20supportteamet%2C%0A%0AJag%20vill%20beg%C3%A4ra%20att%20all%20min%20anv%C3%A4ndardata%20tas%20bort.%0A%0AV%C3%A4nligen%20bekr%C3%A4fta%20n%C3%A4r%20det%20%C3%A4r%20klart.%0A%0ATack!"
+        title="Begär radering av mina uppgifter"
+        aria-label="Begär radering av mina uppgifter via e-post"
+    >
+        <span class="support-email-button__icon" aria-hidden="true">✉️</span>
+        <span class="support-email-button__text">Begär radering</span>
+    </a>
+</div>
 
 <div id="shareModal" class="share-modal" aria-hidden="true">
     <div class="share-modal__backdrop" data-share-close></div>


### PR DESCRIPTION
## Summary
- repositioned the användardata-raderinglänk to a diskret hörnplacering på användardashboarden
- lade till hörnstil för e-postlänken så att den är mindre framträdande men fortsatt åtkomlig och med ikontext

## Testing
- pytest

## Screenshots
![Dashboard med hörnknapp](browser:/invocations/cknnhdsq/artifacts/artifacts/dashboard-removal-button.png)

------
https://chatgpt.com/codex/tasks/task_e_68dadb1278ec832dbe4aac7f7bb47ed1