### PR TITLE
Move dashboard data removal link to discreet corner button

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -13,16 +13,20 @@
 }
 
 .support-actions {
-    margin: 0 0 28px;
+    position: fixed;
+    bottom: 32px;
+    right: 32px;
     display: flex;
     flex-direction: column;
-    gap: 12px;
-    align-items: flex-start;
+    align-items: flex-end;
+    gap: 6px;
+    margin: 0;
+    z-index: 1000;
 }
 
 .support-text {
     margin: 0;
-    font-size: 1rem;
+    font-size: 0.85rem;
     color: #374151;
 }
 
@@ -30,28 +34,54 @@
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    background: #f3f4f6;
-    color: #1f2937;
+    background: rgba(30, 41, 59, 0.82);
+    color: #f9fafb;
     text-decoration: none;
-    padding: 6px 14px;
-    border-radius: 8px;
-    font-size: 0.95rem;
+    padding: 9px 16px;
+    border-radius: 9999px;
+    font-size: 0.85rem;
     font-weight: 500;
-    border: 1px solid #d1d5db;
-    transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-    box-shadow: none;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    transition: opacity 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.25);
+    opacity: 0.7;
+    backdrop-filter: blur(4px);
 }
 
 .support-email-button:hover,
 .support-email-button:focus {
-    background: #e5e7eb;
-    border-color: #cbd5e1;
-    color: #111827;
+    opacity: 1;
+    transform: translateY(-1px);
+    box-shadow: 0 16px 30px rgba(15, 23, 42, 0.32);
 }
 
 .support-email-button:focus {
-    outline: 2px solid rgba(59, 130, 246, 0.35);
-    outline-offset: 2px;
+    outline: 2px solid rgba(148, 163, 184, 0.65);
+    outline-offset: 3px;
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@media (max-width: 768px) {
+    .support-actions {
+        bottom: 18px;
+        right: 18px;
+    }
+
+    .support-email-button {
+        font-size: 0.8rem;
+        padding: 8px 14px;
+    }
 }
 
 .category-list {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -13,8 +13,16 @@
         {% endif %}
     </h1>
     <div class="support-actions" aria-label="Sektion för att kontakta supporten">
-        <p class="support-text">Behöver du radera dina uppgifter? Kontakta oss så hjälper vi dig.</p>
-        <a class="support-email-button" href="mailto:support@utbildningsintyg.se?subject=Beg%C3%A4ran%20om%20radering%20av%20anv%C3%A4ndardata&body=Hej%20supportteamet%2C%0A%0AJag%20vill%20beg%C3%A4ra%20att%20all%20min%20anv%C3%A4ndardata%20tas%20bort.%0A%0AV%C3%A4nligen%20bekr%C3%A4fta%20n%C3%A4r%20det%20%C3%A4r%20klart.%0A%0ATack!">Begär radering av mina uppgifter</a>
+        <a
+            class="support-email-button"
+            href="mailto:support@utbildningsintyg.se?subject=Beg%C3%A4ran%20om%20radering%20av%20anv%C3%A4ndardata&body=Hej%20supportteamet%2C%0A%0AJag%20vill%20beg%C3%A4ra%20att%20all%20min%20anv%C3%A4ndardata%20tas%20bort.%0A%0AV%C3%A4nligen%20bekr%C3%Afta%20n%C3%A4r%20det%20%C3%A4r%20klart.%0A%0ATack!"
+            aria-describedby="supportRemovalHint"
+        >
+            Begär radering av mina uppgifter
+        </a>
+        <p class="support-text visually-hidden" id="supportRemovalHint">
+            Behöver du radera dina uppgifter? Kontakta oss så hjälper vi dig.
+        </p>
     </div>
     {% if category_summary %}
     <section class="category-list" aria-label="Tillgängliga kurskategorier">


### PR DESCRIPTION
## Summary
- flyttade knappen för att begära radering av uppgifter till ett diskret hörnläge och gjorde den mindre framträdande
- lade till en visuellt dold stödtext för skärmläsare för att behålla tillgängligheten

## Testing
- pytest

## Screenshots
![Uppdaterad raderingsknapp i hörnet](browser:/invocations/tsnyydjq/artifacts/artifacts/dashboard-support-button.png)

------
https://chatgpt.com/codex/tasks/task_e_68dadf192560832da79a5f9c08112284