### PR TITLE
Potential fix for code scanning alert no. 49: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -1136,7 +1136,8 @@ def admin_advanced_update(table_name: str, row_id: int):
     try:
         updated = functions.update_table_row(table_name, row_id, values)
     except ValueError as exc:
-        return jsonify({'status': 'error', 'message': str(exc)}), 400
+        logger.exception(f"Failed to update row in table '{table_name}', id={row_id}: {exc}")
+        return jsonify({'status': 'error', 'message': 'Felaktiga data.'}), 400
     if not updated:
         return jsonify({'status': 'error', 'message': 'Posten hittades inte.'}), 404
     functions.log_admin_action(


### PR DESCRIPTION
Potential fix for [https://github.com/Mr-cool08/JK-utbildnings-intyg/security/code-scanning/49](https://github.com/Mr-cool08/JK-utbildnings-intyg/security/code-scanning/49)

To fix the problem, we need to avoid returning the raw exception message `str(exc)` to the external user. Instead, return a generic error message to the user and ensure the full exception details are logged server-side for debugging by developers/administrators.  
The best way to do this in `app.py` is to:  
1. Update the error response on line 1139 from using `str(exc)` to a static, generic string (e.g. "Felaktiga data." or "Ett internt fel uppstod.").  
2. Log the exception (either the stack trace or at least the exception message) using the existing `logging` framework, as this is a server-side Python application.  
Edits are strictly in the context shown, so import `logging` if not already imported, and log to the existing `logger` (assuming it is defined in the file; otherwise, use the root logger).

#### Steps required:
- Within `admin_advanced_update`, in the except block at line 1138–1139, replace the response with a generic message, and add a logging statement for the exception.
- Don't change error codes or other logic.
- Use the existing logger named `logger`, which should be defined in scope.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
