### PR TITLE
Potential fix for code scanning alert no. 47: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -1072,7 +1072,8 @@ def admin_send_password_reset():
     try:
         send_password_reset_email(email, link)
     except RuntimeError as exc:
-        return jsonify({'status': 'error', 'message': str(exc)}), 500
+        logger.exception("Misslyckades att skicka återställningsmejl")
+        return jsonify({'status': 'error', 'message': 'Kunde inte skicka återställningsmejl.'}), 500
 
     functions.log_admin_action(
         admin_name,


### PR DESCRIPTION
Potential fix for [https://github.com/Mr-cool08/JK-utbildnings-intyg/security/code-scanning/47](https://github.com/Mr-cool08/JK-utbildnings-intyg/security/code-scanning/47)

To fix the problem, we should avoid exposing the raw exception message (`str(exc)`) in the HTTP response returned to the user. Instead, we should log the actual exception server-side (using e.g. `logger.exception`), and return a generic error message to the client. This preserves all diagnostic detail for developers/administrators but ensures only non-sensitive, localized information is returned to users.

In this specific case, edit the `except RuntimeError as exc:` block in `admin_send_password_reset` to:
- Log the exception using `logger.exception` (already available in the current file, see line 1068).
- Return a generic error message to the client in the `'message'` field of the JSON response, e.g. `'Kunde inte skicka återställningsmejl.'`.

No new method definitions or imports are required, as appropriate logging facility (`logger`) is already being used elsewhere in the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
