### PR TITLE
Potential fix for code scanning alert no. 46: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -1063,7 +1063,8 @@ def admin_send_password_reset():
     try:
         token = functions.create_password_reset_token(normalized_personnummer, email)
     except ValueError as exc:
-        return jsonify({'status': 'error', 'message': str(exc)}), 404
+        logger.exception("Misslyckades att skapa återställningstoken (ValueError)")
+        return jsonify({'status': 'error', 'message': 'Kunde inte skapa återställning.'}), 404
     except Exception:
         logger.exception("Misslyckades att skapa återställningstoken")
         return jsonify({'status': 'error', 'message': 'Kunde inte skapa återställning.'}), 500


### PR DESCRIPTION
Potential fix for [https://github.com/Mr-cool08/JK-utbildnings-intyg/security/code-scanning/46](https://github.com/Mr-cool08/JK-utbildnings-intyg/security/code-scanning/46)

To fix the issue, you should ensure that no internal exception details (including stack traces, sensitive strings, or system-specific error messages) are returned to the external user. The error message returned should be generic, while the original exception information should be logged server-side for later diagnosis.

Specifically for this location:
- Replace `return jsonify({'status': 'error', 'message': str(exc)}), 404` with a generic message (e.g., `'Kunde inte skapa återställning.'`).
- Log the exception internally for debugging.
- If `logger` is not available in the current context, ensure it is imported or defined.

You only need to modify the function handling the `/admin/api/skicka-aterstallning` POST endpoint (around lines 1065–1069).  
The change is:
- In the first `except ValueError as exc:` block, replace the direct user-facing error with a generic message and log the full exception with `logger.exception`.
- You can copy the logging pattern as seen in the next `except Exception` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
