### PR TITLE
Add supervisor management and dashboard

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -47,6 +47,34 @@ main {
     width: 100%;
 }
 
+.flash-container {
+    max-width: 900px;
+    margin: 24px auto 0;
+    padding: 0 16px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.flash {
+    padding: 12px 16px;
+    border-radius: 6px;
+    margin-bottom: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    font-weight: 500;
+}
+
+.flash.success {
+    background: #e6ffe6;
+    border: 1px solid #7ddc7d;
+    color: #1b6e1b;
+}
+
+.flash.error {
+    background: #ffe6e6;
+    border: 1px solid #e07d7d;
+    color: #6e1b1b;
+}
+
 form {
     background: #fff;
     padding: 16px;
@@ -378,6 +406,25 @@ footer {
     margin-top: 0;
 }
 
+.panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.panel-header form {
+    margin: 0;
+    padding: 0;
+    box-shadow: none;
+    background: transparent;
+}
+
+.panel-header button {
+    margin-top: 0;
+}
+
 .card {
     margin-top: 1.5rem;
     padding: 1.5rem;
@@ -462,6 +509,47 @@ button.danger:focus {
 
 .panel th {
     background: #eef2f7;
+}
+
+.actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: flex-start;
+}
+
+.actions .btn {
+    padding: 0.45rem 0.9rem;
+}
+
+.share-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    background: transparent;
+    padding: 0;
+    box-shadow: none;
+    width: 100%;
+}
+
+.share-form input[type="email"] {
+    width: 100%;
+}
+
+.share-form button {
+    align-self: flex-start;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 .category-select {

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -61,6 +61,61 @@
 </section>
 
 <section class="panel">
+    <h2>Hantera handledare</h2>
+    <p>Skapa nya handledare och koppla dem till befintliga användare.</p>
+    <div class="row">
+        <div class="col">
+            <form id="createSupervisorForm" class="stacked-form">
+                <h3>Skapa handledare</h3>
+                <label for="supervisorName">Namn</label>
+                <input id="supervisorName" name="name" type="text" required placeholder="Namn på handledare">
+
+                <label for="supervisorEmail">E-post</label>
+                <input id="supervisorEmail" name="email" type="email" required placeholder="handledare@example.com">
+
+                <button type="submit">Skapa handledare</button>
+                <p id="createSupervisorMessage" class="message" aria-live="polite" style="display:none"></p>
+            </form>
+        </div>
+        <div class="col">
+            <form id="linkSupervisorForm" class="stacked-form">
+                <h3>Koppla handledare till användare</h3>
+                <label for="linkSupervisorEmail">Handledarens e-post</label>
+                <input id="linkSupervisorEmail" name="email" type="email" required placeholder="handledare@example.com">
+
+                <label for="linkPersonnummer">Användarens personnummer</label>
+                <input id="linkPersonnummer" name="personnummer" type="text" required placeholder="ÅÅMMDDXXXX">
+
+                <button type="submit">Skapa koppling</button>
+                <p id="linkSupervisorMessage" class="message" aria-live="polite" style="display:none"></p>
+            </form>
+        </div>
+    </div>
+
+    <form id="supervisorOverviewForm" class="inline-form">
+        <label for="overviewSupervisorEmail">Visa kopplingar för handledare</label>
+        <input id="overviewSupervisorEmail" name="email" type="email" required placeholder="handledare@example.com">
+        <button type="submit">Visa kopplingar</button>
+        <span id="supervisorOverviewMessage" class="message" aria-live="polite" style="display:none"></span>
+    </form>
+
+    <div id="supervisorOverviewCard" class="card" hidden>
+        <h3 id="supervisorOverviewTitle">Kopplade användare</h3>
+        <div class="table-scroll">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Användarnamn</th>
+                        <th>Åtgärder</th>
+                    </tr>
+                </thead>
+                <tbody id="supervisorOverviewBody"></tbody>
+            </table>
+        </div>
+    </div>
+</section>
+
+<section class="panel">
     <h2>Hantera befintliga intyg</h2>
     <p>Sök fram en användares PDF:er för att ändra kategori eller ta bort filen.</p>
     <form id="pdfLookupForm" class="inline-form">

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,7 +12,10 @@
     <nav>
         <a class="brand" href="/">Hem</a>
         <div class="nav-links">
-            {% if session.get('user_logged_in') %}
+            {% if session.get('supervisor_logged_in') %}
+                <a href="{{ url_for('supervisor_dashboard') }}">Handledarpanel</a>
+                <a href="/logout">Logga ut</a>
+            {% elif session.get('user_logged_in') %}
                 <a href="/dashboard">Intyg</a>
                 <a href="/logout">Logga ut</a>
             {% elif session.get('admin_logged_in') %}
@@ -20,9 +23,19 @@
                 <a href="/logout">Logga ut</a>
             {% else %}
                 <a href="/login">Logga in</a>
+                <a href="{{ url_for('supervisor_login') }}">Handledarinloggning</a>
             {% endif %}
         </div>
     </nav>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            <div class="flash-container">
+                {% for category, message in messages %}
+                    <div class="flash {{ category }}">{{ message }}</div>
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endwith %}
     <main>
         {% block content %}{% endblock %}
     </main>

--- a/templates/create_supervisor.html
+++ b/templates/create_supervisor.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% block title %}Aktivera handledarkonto{% endblock %}
+{% block content %}
+    <div class="create-account">
+        <h2>Aktivera handledarkonto</h2>
+        {% if invalid %}
+            <p class="error">Länken är ogiltig eller har redan använts. Kontakta administratören om du behöver en ny inbjudan.</p>
+        {% else %}
+            {% if error %}
+                <p class="error">{{ error }}</p>
+            {% endif %}
+            <p>Välj ett starkt lösenord för ditt handledarkonto. Lösenordet måste vara minst åtta tecken långt.</p>
+            <form method="post">
+                <label for="password">Lösenord</label>
+                <input type="password" id="password" name="password" minlength="8" required>
+
+                <label for="confirm">Bekräfta lösenord</label>
+                <input type="password" id="confirm" name="confirm" minlength="8" required>
+
+                <button type="submit">Aktivera konto</button>
+            </form>
+            <p class="license-note">Genom att fortsätta accepterar du villkoren i vårt licensavtal.</p>
+            <a href="{{ url_for('license') }}" class="license-link" target="_blank">Läs licensavtalet</a>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/templates/supervisor_dashboard.html
+++ b/templates/supervisor_dashboard.html
@@ -1,0 +1,62 @@
+{% extends 'base.html' %}
+{% block title %}Handledarpanel{% endblock %}
+{% block content %}
+    <h1>Handledarpanel</h1>
+    <p>Välkommen {{ supervisor_name }}. Här ser du alla användare som administratören har kopplat till dig.</p>
+    {% if users %}
+        {% for user in users %}
+            <section class="panel" id="user-{{ user.personnummer_hash }}">
+                <div class="panel-header">
+                    <h2>{{ user.username }}</h2>
+                    <form method="post" action="{{ url_for('supervisor_remove_connection_route', person_hash=user.personnummer_hash) }}" onsubmit="return confirm('Är du säker på att du vill ta bort kopplingen?');">
+                        <input type="hidden" name="anchor" value="user-{{ user.personnummer_hash }}">
+                        <button type="submit" class="danger">Ta bort koppling</button>
+                    </form>
+                </div>
+                {% if user.pdfs %}
+                    <div class="table-scroll">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Filnamn</th>
+                                    <th>Kategorier</th>
+                                    <th>Åtgärder</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for pdf in user.pdfs %}
+                                    <tr>
+                                        <td>{{ pdf.filename }}</td>
+                                        <td>
+                                            {% if pdf.category_labels %}
+                                                {{ pdf.category_labels | join(', ') }}
+                                            {% else %}
+                                                Okategoriserat
+                                            {% endif %}
+                                        </td>
+                                        <td>
+                                            <div class="actions">
+                                                <a class="btn" href="{{ url_for('supervisor_download_pdf', person_hash=user.personnummer_hash, pdf_id=pdf.id) }}?download=0" target="_blank">Visa</a>
+                                                <a class="btn" href="{{ url_for('supervisor_download_pdf', person_hash=user.personnummer_hash, pdf_id=pdf.id) }}">Ladda ner</a>
+                                                <form class="share-form" method="post" action="{{ url_for('supervisor_share_pdf_route', person_hash=user.personnummer_hash, pdf_id=pdf.id) }}">
+                                                    <input type="hidden" name="anchor" value="user-{{ user.personnummer_hash }}">
+                                                    <label for="share-{{ user.personnummer_hash }}-{{ pdf.id }}" class="sr-only">E-postadress</label>
+                                                    <input type="email" id="share-{{ user.personnummer_hash }}-{{ pdf.id }}" name="recipient_email" required placeholder="mottagare@example.com">
+                                                    <button type="submit">Dela intyg</button>
+                                                </form>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                {% else %}
+                    <p>Inga intyg är uppladdade för denna användare ännu.</p>
+                {% endif %}
+            </section>
+        {% endfor %}
+    {% else %}
+        <p>Det finns inga kopplade användare just nu. Kontakta administratören om du behöver åtkomst.</p>
+    {% endif %}
+{% endblock %}

--- a/templates/supervisor_login.html
+++ b/templates/supervisor_login.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block title %}Handledarinloggning{% endblock %}
+{% block content %}
+    <h1>Handledarinloggning</h1>
+    <p>Ange din e-postadress och ditt lösenord för att komma åt de intyg du har behörighet till.</p>
+    {% if error %}
+        <p class="error">{{ error }}</p>
+    {% endif %}
+    <form method="post">
+        <label for="email">E-post</label>
+        <input type="email" id="email" name="email" required placeholder="handledare@example.com">
+
+        <label for="password">Lösenord</label>
+        <input type="password" id="password" name="password" required>
+
+        <button type="submit">Logga in</button>
+    </form>
+{% endblock %}

--- a/tests/test_supervisor_features.py
+++ b/tests/test_supervisor_features.py
@@ -1,0 +1,177 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import app  # noqa: E402
+import functions  # noqa: E402
+
+
+def _admin_client():
+    client = app.app.test_client()
+    with client.session_transaction() as sess:
+        sess["admin_logged_in"] = True
+        sess["admin_username"] = "admin"
+    return client
+
+
+@pytest.fixture
+def supervisor_setup(empty_db):
+    email = "chef@example.com"
+    name = "Chef Test"
+    user_email = "user@example.com"
+    user_name = "Test Användare"
+    personnummer = "19900101-1234"
+
+    assert functions.admin_create_user(user_email, user_name, personnummer)
+    pnr_hash = functions.hash_value(functions.normalize_personnummer(personnummer))
+    assert functions.user_create_user("Hemligt123", pnr_hash)
+    functions.store_pdf_blob(pnr_hash, "intyg.pdf", b"%PDF-1.4", [])
+
+    assert functions.admin_create_supervisor(email, name)
+    email_hash = functions.get_supervisor_email_hash(email)
+    assert functions.check_pending_supervisor_hash(email_hash)
+    assert functions.supervisor_activate_account(email_hash, "StarktLosen123")
+
+    success, reason = functions.admin_link_supervisor_to_user(email, personnummer)
+    assert success and reason == "created"
+
+    return {
+        "email": email,
+        "name": name,
+        "email_hash": email_hash,
+        "personnummer": personnummer,
+        "personnummer_hash": pnr_hash,
+        "user_name": user_name,
+    }
+
+
+def _supervisor_client(email_hash, name):
+    client = app.app.test_client()
+    with client.session_transaction() as sess:
+        sess["supervisor_logged_in"] = True
+        sess["supervisor_email_hash"] = email_hash
+        sess["supervisor_name"] = name
+    return client
+
+
+def test_supervisor_activation_flow(empty_db):
+    email = "handledare@example.com"
+    name = "Handledare"
+    assert functions.admin_create_supervisor(email, name)
+    email_hash = functions.get_supervisor_email_hash(email)
+    assert functions.check_pending_supervisor_hash(email_hash)
+    with pytest.raises(ValueError):
+        functions.supervisor_activate_account(email_hash, "kort")
+    assert functions.supervisor_activate_account(email_hash, "LångtLösen123")
+    assert not functions.check_pending_supervisor_hash(email_hash)
+    assert functions.supervisor_exists(email)
+
+
+def test_supervisor_dashboard_lists_users(supervisor_setup):
+    client = _supervisor_client(
+        supervisor_setup["email_hash"], supervisor_setup["name"]
+    )
+    response = client.get("/handledare")
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert supervisor_setup["user_name"] in body
+    assert "intyg.pdf" in body
+
+
+def test_supervisor_share_pdf(monkeypatch, supervisor_setup):
+    captured = {}
+
+    def fake_send(recipient, attachments, sender, owner_name=None):
+        captured["recipient"] = recipient
+        captured["attachments"] = attachments
+        captured["sender"] = sender
+        captured["owner"] = owner_name
+
+    monkeypatch.setattr(app, "send_pdf_share_email", fake_send)
+
+    client = _supervisor_client(
+        supervisor_setup["email_hash"], supervisor_setup["name"]
+    )
+    pdfs = functions.get_user_pdfs(supervisor_setup["personnummer_hash"])
+    pdf_id = pdfs[0]["id"]
+    response = client.post(
+        f"/handledare/dela/{supervisor_setup['personnummer_hash']}/{pdf_id}",
+        data={"recipient_email": "mottagare@example.com", "anchor": "user-anchor"},
+    )
+    assert response.status_code == 302
+    assert captured["recipient"] == "mottagare@example.com"
+    assert captured["sender"] == supervisor_setup["name"]
+    assert captured["owner"] == supervisor_setup["user_name"]
+    assert captured["attachments"][0][0] == "intyg.pdf"
+
+
+def test_supervisor_remove_connection(supervisor_setup):
+    client = _supervisor_client(
+        supervisor_setup["email_hash"], supervisor_setup["name"]
+    )
+    response = client.post(
+        f"/handledare/kopplingar/{supervisor_setup['personnummer_hash']}/ta-bort",
+        data={"anchor": "user-anchor"},
+    )
+    assert response.status_code == 302
+    assert not functions.supervisor_has_access(
+        supervisor_setup["email_hash"], supervisor_setup["personnummer_hash"]
+    )
+
+
+def test_admin_create_supervisor_api(empty_db, monkeypatch):
+    sent = {}
+
+    def fake_send(email, link):
+        sent["email"] = email
+        sent["link"] = link
+
+    monkeypatch.setattr(app, "send_creation_email", fake_send)
+
+    client = _admin_client()
+    response = client.post(
+        "/admin/api/handledare/skapa",
+        json={"name": "Chef", "email": "chef@example.com"},
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["status"] == "success"
+    assert "link" in data
+    assert sent["email"] == "chef@example.com"
+
+
+def test_admin_link_supervisor_api(supervisor_setup):
+    functions.supervisor_remove_connection(
+        supervisor_setup["email_hash"], supervisor_setup["personnummer_hash"]
+    )
+    client = _admin_client()
+    response = client.post(
+        "/admin/api/handledare/koppla",
+        json={
+            "email": supervisor_setup["email"],
+            "personnummer": supervisor_setup["personnummer"],
+        },
+    )
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "success"
+    assert functions.supervisor_has_access(
+        supervisor_setup["email_hash"], supervisor_setup["personnummer_hash"]
+    )
+
+
+def test_admin_supervisor_overview_api(supervisor_setup):
+    client = _admin_client()
+    response = client.post(
+        "/admin/api/handledare/oversikt",
+        json={"email": supervisor_setup["email"]},
+    )
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "success"
+    data = payload["data"]
+    assert data["name"] == supervisor_setup["name"]
+    assert data["connections"]


### PR DESCRIPTION
## Sammanfattning
- införde databastabeller och backend-logik för att hantera handledarkonton och deras kopplingar till användare
- uppdaterade adminpanelen med formulär för att skapa handledare, skapa kopplingar och visa befintliga kopplingar
- lade till handledarinloggning och en ny handledarpanel där kopplade användares intyg kan visas, laddas ned, delas och kopplingar tas bort

## Tester
- pytest

## Skärmdump
![Handledarpanel](browser:/invocations/tifnmsyw/artifacts/artifacts/supervisor-dashboard.png)

------
https://chatgpt.com/codex/tasks/task_e_68dae86d492c832dbdacacfe87b8ddfb