### PR TITLE
Uppdatera startsidans innehåll och layout

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -241,9 +241,191 @@ a.license-link:hover {
     text-decoration: underline;
 }
 
+/* --- Startsida/hero & features --- */
 .hero {
+    background: linear-gradient(135deg, #0d6efd, #6610f2);
+    color: #fff;
+    padding: 48px 32px;
+    border-radius: 16px;
     text-align: center;
-    padding: 60px 20px;
+    box-shadow: 0 8px 24px rgba(13, 110, 253, 0.25);
+}
+
+.hero-eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.85);
+    margin: 0 0 12px;
+}
+
+.hero h1 {
+    margin: 0 0 12px;
+    font-size: 2.4rem;
+}
+
+.hero p {
+    margin: 0 auto 20px;
+    max-width: 600px;
+    line-height: 1.6;
+}
+
+.hero .actions {
+    display: flex;
+    justify-content: center;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.btn-outline {
+    background: transparent;
+    border: 2px solid #fff;
+    color: #fff;
+}
+
+.btn-outline:hover {
+    background: rgba(255, 255, 255, 0.15);
+}
+
+.hero-highlights {
+    margin: 28px auto 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 18px;
+    font-weight: 600;
+}
+
+.hero-highlights li {
+    background: rgba(255, 255, 255, 0.15);
+    padding: 10px 18px;
+    border-radius: 999px;
+}
+
+.features {
+    margin-top: 56px;
+    text-align: center;
+}
+
+.features h2 {
+    margin-bottom: 24px;
+}
+
+.feature-grid {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.feature {
+    background: #fff;
+    padding: 24px;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    text-align: left;
+}
+
+.feature h3 {
+    margin-top: 0;
+}
+
+.process {
+    margin-top: 64px;
+}
+
+.process h2 {
+    text-align: center;
+}
+
+.process-steps {
+    counter-reset: steg;
+    display: grid;
+    gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    list-style: none;
+    margin: 32px 0 0;
+    padding: 0;
+}
+
+.process-steps li {
+    background: #fff;
+    padding: 24px;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+    position: relative;
+}
+
+.process-steps li::before {
+    counter-increment: steg;
+    content: counter(steg);
+    position: absolute;
+    top: -16px;
+    left: 20px;
+    background: #0d6efd;
+    color: #fff;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    box-shadow: 0 6px 14px rgba(13, 110, 253, 0.3);
+}
+
+.step-title {
+    display: block;
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+
+.trust {
+    margin-top: 64px;
+}
+
+.trust h2 {
+    text-align: center;
+}
+
+.trust-grid {
+    margin-top: 32px;
+    display: grid;
+    gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.trust-card {
+    background: #fff;
+    padding: 24px;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+}
+
+.cta-banner {
+    margin-top: 72px;
+    background: #fff;
+    border-radius: 16px;
+    padding: 40px 32px;
+    text-align: center;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+}
+
+.cta-banner h2 {
+    margin-top: 0;
+}
+
+.cta-banner p {
+    max-width: 520px;
+    margin: 12px auto 24px;
+    line-height: 1.6;
+}
+
+.cta-banner .btn {
+    margin-top: 0;
+    padding: 12px 24px;
+    font-size: 1rem;
 }
 
 footer {
@@ -251,36 +433,6 @@ footer {
     padding: 20px;
     background: #333;
     color: #fff;
-}
-
-/* --- Startsida/hero & features --- */
-.hero .actions {
-    margin-top: 24px;
-    display: flex;
-    justify-content: center;
-    gap: 16px;
-}
-
-.features {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 20px;
-    padding: 40px 20px;
-}
-
-.feature {
-    background: #fff;
-    padding: 20px;
-    border-radius: 8px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    max-width: 260px;
-    flex: 1 1 250px;
-    text-align: center;
-}
-
-.feature h2 {
-    margin-top: 0;
 }
 
 /* --- Konto­skapande-sida --- */
@@ -348,17 +500,29 @@ footer {
         flex-direction: column;
     }
 
+    .hero {
+        padding: 40px 20px;
+    }
+
+    .hero h1 {
+        font-size: 2rem;
+    }
+
     .hero .actions {
+        flex-direction: column;
+        gap: 12px;
+        width: 100%;
+    }
+
+    .hero-highlights {
         flex-direction: column;
         gap: 12px;
     }
 
-    .features {
-        flex-direction: column;
-    }
-
-    .feature {
-        max-width: 100%;
+    .feature-grid,
+    .process-steps,
+    .trust-grid {
+        grid-template-columns: 1fr;
     }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,25 +12,77 @@
 {% endblock %}
 {% block content %}
 <div class="hero">
-    <h1>Hantera utbildningsintyg enkelt</h1>
-    <p>JK Utbildnings Intyg hjälper dig att lagra och komma åt intyg var du än är.</p>
+    <p class="hero-eyebrow">Digitalt arkiv för utbildningsintyg</p>
+    <h1>Trygg hantering av utbildningsintyg</h1>
+    <p>JK Utbildnings Intyg hjälper utbildningsföretag och kursdeltagare att lagra, verifiera och hitta rätt intyg på några sekunder.</p>
     <div class="actions">
-        <a class="btn" href="/login">Användarinloggning</a>
+        <a class="btn" href="/login">Logga in</a>
+        <a class="btn btn-outline" href="#sa-fungerar">Utforska tjänsten</a>
     </div>
+    <ul class="hero-highlights">
+        <li>GDPR-anpassad lagring inom EU</li>
+        <li>Säker delning av signerade PDF-intyg</li>
+        <li>Stöd för både administratörer och studerande</li>
+    </ul>
 </div>
 
 <section class="features">
-    <div class="feature">
-        <h2>Organisera</h2>
-        <p>Spara alla dina utbildningsintyg på ett ställe.</p>
+    <h2>Funktioner som sparar tid</h2>
+    <div class="feature-grid">
+        <article class="feature">
+            <h3>Organisera smart</h3>
+            <p>Samla alla utbildningsintyg på ett ställe med tydlig struktur efter personnummer.</p>
+        </article>
+        <article class="feature">
+            <h3>Verifiera direkt</h3>
+            <p>Dela säkra länkar till PDF-intyg och ge mottagare möjlighet att kontrollera äktheten.</p>
+        </article>
+        <article class="feature">
+            <h3>Åtkomst överallt</h3>
+            <p>Logga in från dator, mobil eller surfplatta och hämta intyg när som helst.</p>
+        </article>
     </div>
-    <div class="feature">
-        <h2>Verifiera</h2>
-        <p>Dela och verifiera intyg enkelt.</p>
+</section>
+
+<section id="sa-fungerar" class="process">
+    <h2>Så fungerar det</h2>
+    <ol class="process-steps">
+        <li>
+            <span class="step-title">Registrera deltagare</span>
+            <p>Administratören lägger till nya deltagare och laddar upp deras senaste intyg.</p>
+        </li>
+        <li>
+            <span class="step-title">Aktivera konto</span>
+            <p>Deltagaren får en länk via e-post, väljer lösenord och får tillgång till sitt personliga arkiv.</p>
+        </li>
+        <li>
+            <span class="step-title">Hämta och dela</span>
+            <p>Intygen kan laddas ned på sekunder och delas med arbetsgivare eller myndigheter vid behov.</p>
+        </li>
+    </ol>
+</section>
+
+<section class="trust">
+    <h2>Varför organisationer väljer JK Utbildnings Intyg</h2>
+    <div class="trust-grid">
+        <article class="trust-card">
+            <h3>Säkerhet först</h3>
+            <p>Krypterade lösenord, kontrollerade filtyper och tydlig loggning skyddar känsliga uppgifter.</p>
+        </article>
+        <article class="trust-card">
+            <h3>Enkel administration</h3>
+            <p>Smidiga formulär och tydliga listor gör det lätt att hålla koll på uppladdade intyg.</p>
+        </article>
+        <article class="trust-card">
+            <h3>Support nära till hands</h3>
+            <p>Teamet bakom tjänsten hjälper dig hela vägen från uppstart till löpande drift.</p>
+        </article>
     </div>
-    <div class="feature">
-        <h2>Åtkomst</h2>
-        <p>Logga in från valfri enhet för att se dina intyg.</p>
-    </div>
+</section>
+
+<section class="cta-banner">
+    <h2>Klara att digitalisera intygen?</h2>
+    <p>Bjud in dina administratörer, logga in och kom igång med en trygg och enkel lösning redan idag.</p>
+    <a class="btn" href="/login">Starta nu</a>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Sammanfattning
- bygger om startsidans hjältesektion med tydligare budskap, knappar och unika säljpunkter
- lägger till avsnitt för funktioner, arbetsflöde, kundlöften och en avslutande uppmaning
- uppdaterar basstilarna för att stödja den nya layouten och responsivt beteende

## Testning
- pytest

## Skärmdumpar
![Ny startsida](browser:/invocations/jswnzqsk/artifacts/artifacts/home-page.png)


------
https://chatgpt.com/codex/tasks/task_e_68dae8aa54fc832d8846a479f41601a7