### PR TITLE
Add skip link to main content for better keyboard navigation

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -9,6 +9,26 @@ body {
     flex-direction: column;
 }
 
+.skip-link {
+    position: absolute;
+    left: 50%;
+    top: -100px;
+    transform: translateX(-50%);
+    background: #fff;
+    color: #0d6efd;
+    padding: 10px 16px;
+    border-radius: 6px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    font-weight: 600;
+    text-decoration: none;
+    transition: top 0.2s ease;
+    z-index: 1000;
+}
+
+.skip-link:focus-visible {
+    top: 16px;
+}
+
 nav {
     background: #333;
     color: #fff;

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,6 +9,7 @@
     {% block head %}{% endblock %}
 </head>
 <body>
+    <a class="skip-link" href="#main-content">Hoppa till huvudinnehållet</a>
     <nav>
         <a class="brand" href="/">Hem</a>
         <div class="nav-links">
@@ -36,7 +37,7 @@
             </div>
         {% endif %}
     {% endwith %}
-    <main>
+    <main id="main-content">
         {% block content %}{% endblock %}
     </main>
     <footer>


### PR DESCRIPTION
## Summary
- add a skip link at the top of the base template so keyboard users can hop directly to the main content
- style the skip link so it becomes visible on focus while remaining hidden otherwise

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68daf73d3764832d9b67dbc08561ef31