### PR TITLE
Lägg till kryptering för lagrade PDF-filer

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -20,6 +20,11 @@ secret_key=hemligt_session_varde
 # Salt used for hashing personal data such as email and personnummer
 HASH_SALT=extra_salt_for_hash
 
+# Krypteringsnycklar för PDF-lagring. Använd `python -m cryptography.fernet`
+# för att generera en nyckel och spara samma värde här samt i din riktiga `.env`
+# så att filer kan dekrypteras även efter omstart.
+PDF_ENCRYPTION_KEYS=w3dy6b8eBx0O0TADb8QWfXBxr6nMPNqY6kmv4hKoT1c=
+
 # Database configuration
 # Supply credentials for the external PostgreSQL server that stores
 # application data. POSTGRES_HOST is required when DATABASE_URL is empty.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This web application manages the issuance and storage of course certificates. It
    PDF_ENCRYPTION_KEYS="<ny primär nyckel>,<tidigare nyckel>"
    ```
 
-   Uppdatera variabeln och starta om applikationen för att rotera nycklar; behåll tidigare nycklar i listan tills alla äldre filer har krypterats om eller inte längre behövs.
+   Spara nyckelvärdet i din `.env`-fil (se `.example.env` för ett exempel) så att samma nyckel används vid varje omstart. Uppdatera variabeln och starta om applikationen för att rotera nycklar; behåll tidigare nycklar i listan tills alla äldre filer har krypterats om eller inte längre behövs.
 3. **Run the application**
    ```bash
    python app.py

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ This web application manages the issuance and storage of course certificates. It
    pip install -r requirements.txt
    ```
 2. **Configure environment variables** – copy `.example.env` to `.env` and update the values to match your setup. Provide the credentials for your external PostgreSQL server by setting `POSTGRES_HOST`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, and optionally `POSTGRES_PORT`. The container derives the SQLAlchemy connection string from these values whenever `DATABASE_URL` is empty. If you prefer, you can instead set `DATABASE_URL` directly to a PostgreSQL connection string. For local development or automated tests you may temporarily enable `ENABLE_LOCAL_TEST_DB` to let the app create a SQLite database file defined by `LOCAL_TEST_DB_PATH`; the flag is disabled by default so production deployments still require PostgreSQL.
+
+   *Säker PDF-lagring*: sätt `PDF_ENCRYPTION_KEYS` till en kommaseparerad lista med [Fernet-nycklar](https://cryptography.io/en/latest/fernet/). Den första nyckeln används för att kryptera nyuppladdade filer och samtliga nycklar prövas i turordning vid dekryptering. Exempel:
+
+   ```bash
+   PDF_ENCRYPTION_KEYS="<ny primär nyckel>,<tidigare nyckel>"
+   ```
+
+   Uppdatera variabeln och starta om applikationen för att rotera nycklar; behåll tidigare nycklar i listan tills alla äldre filer har krypterats om eller inte längre behövs.
 3. **Run the application**
    ```bash
    python app.py

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,3 +23,13 @@ Inte utnyttjar sårbarheten för annat än att verifiera dess existens.
 Inte delar informationen offentligt förrän vi har hunnit åtgärda problemet.
 
 Tillsammans kan vi skapa en tryggare digital miljö.
+
+## Kryptering av lagrade PDF:er
+
+Alla PDF-intyg krypteras med Fernet innan de sparas i databasen. Du måste konfigurera miljövariabeln `PDF_ENCRYPTION_KEYS` med minst en giltig Fernet-nyckel (till exempel genererad via `python -m cryptography.fernet`). Vid nyckelrotation lägger du till den nya nyckeln först i listan och behåller tidigare nycklar efteråt:
+
+```
+PDF_ENCRYPTION_KEYS="<ny primär nyckel>,<gammal nyckel>"
+```
+
+Starta om applikationen efter att variabeln har uppdaterats så att den nya nyckelordningen börjar användas. Systemet testar samtliga nycklar i ordning när ett dokument dekrypteras, vilket gör att äldre filer fortsätter att vara läsbara tills du tar bort deras nycklar från listan.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ Tillsammans kan vi skapa en tryggare digital miljö.
 
 ## Kryptering av lagrade PDF:er
 
-Alla PDF-intyg krypteras med Fernet innan de sparas i databasen. Du måste konfigurera miljövariabeln `PDF_ENCRYPTION_KEYS` med minst en giltig Fernet-nyckel (till exempel genererad via `python -m cryptography.fernet`). Vid nyckelrotation lägger du till den nya nyckeln först i listan och behåller tidigare nycklar efteråt:
+Alla PDF-intyg krypteras med Fernet innan de sparas i databasen. Spara nyckelvärdet i din permanenta `.env`-fil så att samma nyckel används även efter en omstart. Du måste konfigurera miljövariabeln `PDF_ENCRYPTION_KEYS` med minst en giltig Fernet-nyckel (till exempel genererad via `python -m cryptography.fernet`). Vid nyckelrotation lägger du till den nya nyckeln först i listan och behåller tidigare nycklar efteråt:
 
 ```
 PDF_ENCRYPTION_KEYS="<ny primär nyckel>,<gammal nyckel>"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ itsdangerous==2.1.2
 click==8.1.7
 SQLAlchemy==2.0.43
 psycopg[binary]==3.2.10
+cryptography==43.0.3
 
 # Optional (for PDF validation if you later add more advanced checks)
 # PyPDF2==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ itsdangerous==2.1.2
 click==8.1.7
 SQLAlchemy==2.0.43
 psycopg[binary]==3.2.10
-cryptography==43.0.3
+cryptography==46.0.1
 
 # Optional (for PDF validation if you later add more advanced checks)
 # PyPDF2==3.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,10 @@ import werkzeug
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault(
+    "PDF_ENCRYPTION_KEYS",
+    "dLw8JfQULF4tSHzxU_KgQPXujR5Ph9l9-Vw2hHkPnnI=",
+)
 
 import app  # noqa: E402
 import functions  # noqa: E402

--- a/tests/test_admin_upload.py
+++ b/tests/test_admin_upload.py
@@ -50,8 +50,10 @@ def test_admin_upload_existing_user_only_saves_pdf(empty_db):
             )
         )
     assert len(rows) == 1
-    assert rows[0].content == pdf_bytes
     assert rows[0].categories == COURSE_CATEGORIES[0][0]
+    filename, decrypted = functions.get_pdf_content(pnr_hash, rows[0].id)
+    assert filename == rows[0].filename
+    assert decrypted == pdf_bytes
 
 
 def test_admin_upload_existing_email(empty_db):
@@ -90,8 +92,10 @@ def test_admin_upload_existing_email(empty_db):
             )
         )
     assert len(rows) == 1
-    assert rows[0].content == pdf_bytes
     assert rows[0].categories == COURSE_CATEGORIES[1][0]
+    filename, decrypted = functions.get_pdf_content(new_hash, rows[0].id)
+    assert filename == rows[0].filename
+    assert decrypted == pdf_bytes
 
 
 def test_admin_upload_pending_user(empty_db):
@@ -132,8 +136,10 @@ def test_admin_upload_pending_user(empty_db):
             )
         )
     assert len(rows) == 1
-    assert rows[0].content == pdf_bytes
     assert rows[0].categories == COURSE_CATEGORIES[0][0]
+    filename, decrypted = functions.get_pdf_content(pnr_hash, rows[0].id)
+    assert filename == rows[0].filename
+    assert decrypted == pdf_bytes
 
 
 def test_admin_upload_multiple_pdfs_with_individual_categories(empty_db):
@@ -179,10 +185,15 @@ def test_admin_upload_multiple_pdfs_with_individual_categories(empty_db):
         )
 
     assert len(rows) == 2
-    stored = {(row.categories, row.content) for row in rows}
-    assert stored == {
-        (COURSE_CATEGORIES[0][0], pdf_first),
-        (COURSE_CATEGORIES[1][0], pdf_second),
+    decrypted_by_category = {}
+    for row in rows:
+        filename, decrypted = functions.get_pdf_content(personnummer_hash, row.id)
+        assert filename == row.filename
+        decrypted_by_category[row.categories] = decrypted
+
+    assert decrypted_by_category == {
+        COURSE_CATEGORIES[0][0]: pdf_first,
+        COURSE_CATEGORIES[1][0]: pdf_second,
     }
 
 

--- a/tests/test_save_pdf_for_user.py
+++ b/tests/test_save_pdf_for_user.py
@@ -27,6 +27,12 @@ def test_save_pdf_for_user(empty_db):
             )
         ).first()
     assert row is not None
-    assert row.content == pdf_bytes
     assert row.filename == result["filename"]
     assert row.categories == category
+
+    personnummer_hash = functions.hash_value(
+        functions.normalize_personnummer("19900101-1234")
+    )
+    filename, decrypted = functions.get_pdf_content(personnummer_hash, row.id)
+    assert filename == result["filename"]
+    assert decrypted == pdf_bytes


### PR DESCRIPTION
## Summary
- lägger till Fernet-kryptering för uppladdade PDF:er och stöd för flera nycklar vid dekryptering
- dokumenterar hur nycklar hanteras och roteras i README och SECURITY
- uppdaterar enhetstester för att verifiera krypterad lagring och dekryptering samt justerar testkonfigurationen

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68daf727f2ac832d972121b6e2ca2d99