### PR TITLE
Add accessible skip link for main content

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -53,6 +53,27 @@ body {
     line-height: 1.6;
 }
 
+.skip-link {
+    position: absolute;
+    top: 1rem;
+    left: 50%;
+    transform: translate(-50%, -150%);
+    padding: 0.75rem 1.25rem;
+    background: var(--color-primary);
+    color: #fff;
+    border-radius: var(--radius-pill);
+    box-shadow: var(--shadow-sm);
+    font-weight: 600;
+    opacity: 0;
+    transition: transform var(--transition-base), opacity var(--transition-base);
+    z-index: 1000;
+}
+
+.skip-link:focus-visible {
+    transform: translate(-50%, 0);
+    opacity: 1;
+}
+
 a {
     color: var(--color-primary);
     text-decoration: none;

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,6 +9,7 @@
     {% block head %}{% endblock %}
 </head>
 <body>
+    <a class="skip-link" href="#main-content">Hoppa till innehåll</a>
     <nav class="site-nav">
         <div class="nav-inner">
             <a class="brand" href="/">Hem</a>
@@ -38,7 +39,7 @@
             </div>
         {% endif %}
     {% endwith %}
-    <main>
+    <main id="main-content">
         {% block content %}{% endblock %}
     </main>
     <footer class="site-footer">


### PR DESCRIPTION
## Summary
- lägger till en hoppa-till-innehållslänk i basmallen för bättre tangentbordsnavigering
- stylar hoppa-länken så att den syns vid focus-visible men är dold annars

## Testing
- pytest

## Screenshots
![Skip-link i fokus](browser:/invocations/mzqeftyl/artifacts/artifacts/skip-link-focus.png)


------
https://chatgpt.com/codex/tasks/task_e_68daf95a8eac832d8a03a165fb2460e8