### PR TITLE
Remove per-intyg share buttons and wrap long filenames

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -145,11 +145,6 @@
     font-weight: 600;
 }
 
-.pdf-meta {
-    color: var(--color-text-muted);
-    font-size: 0.95rem;
-}
-
 .pdf-entry {
     display: flex;
     align-items: flex-start;
@@ -169,18 +164,17 @@
     flex-direction: column;
     gap: 0.35rem;
     flex: 1;
+    min-width: 0;
 }
 
-.pdf-actions {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    align-items: flex-start;
-    flex-shrink: 0;
+.pdf-details a {
+    overflow-wrap: anywhere;
 }
 
-.pdf-actions .btn {
-    padding: 0.45rem 1rem;
+.pdf-meta {
+    color: var(--color-text-muted);
+    font-size: 0.95rem;
+    overflow-wrap: anywhere;
 }
 
 .share-selection {

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -300,14 +300,6 @@
 
       const selected = getSelectedPdfs();
       shareSelectedButton.disabled = selected.length === 0;
-
-      if (selected.length === 1) {
-        shareSelectedButton.textContent = 'Dela markerat intyg';
-      } else if (selected.length > 1) {
-        shareSelectedButton.textContent = `Dela ${selected.length} markerade intyg`;
-      } else {
-        shareSelectedButton.textContent = 'Dela markerade intyg';
-      }
     }
 
     selectionCheckboxes.forEach((checkbox) => {
@@ -327,23 +319,6 @@
       });
     }
 
-    const shareButtons = Array.from(
-      document.querySelectorAll('[data-share-button]')
-    );
-
-    shareButtons.forEach((button) => {
-      button.addEventListener('click', () => {
-        const pdfId = Number.parseInt(button.dataset.pdfId || '', 10);
-        const pdfName = button.dataset.pdfName || 'intyget';
-
-        if (!Number.isInteger(pdfId)) {
-          setFeedback('Det gick inte att identifiera intyget.', 'error');
-          return;
-        }
-
-        openShareModal([{ id: pdfId, name: pdfName }]);
-      });
-    });
   }
 
   setupFiltering();

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -87,17 +87,6 @@
 
                             </span>
                         </div>
-                        <div class="pdf-actions">
-                            <button
-                                type="button"
-                                class="btn btn-secondary share-button"
-                                data-share-button
-                                data-pdf-id="{{ pdf.id }}"
-                                data-pdf-name="{{ pdf.filename }}"
-                            >
-                                Dela via e-post
-                            </button>
-                        </div>
                     </div>
                 </li>
                 {% endfor %}


### PR DESCRIPTION
## Summary
- remove the per-intyg delningsknapp from the dashboard and rely on the gemensamma "Dela markerade intyg"-knappen
- adjust dashboard styles so långa filnamn bryts inom listan och inte rinner utanför
- simplify share script logic to hålla knappen inaktiverad tills markeringar finns utan att ändra dess text

## Testing
- pytest

## Screenshot
- Kunde inte ta fram en skärmdump i denna miljö eftersom applikationen kräver ytterligare konfiguration och data för att rendera instrumentpanelen.


------
https://chatgpt.com/codex/tasks/task_e_68dafcc60220832da8437897f9837e3c