### PR TITLE
Refactor PDF encryption to PBKDF2-derived AES

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -20,10 +20,11 @@ secret_key=hemligt_session_varde
 # Salt used for hashing personal data such as email and personnummer
 HASH_SALT=extra_salt_for_hash
 
-# Krypteringsnycklar för PDF-lagring. Använd `python -m cryptography.fernet`
-# för att generera en nyckel och spara samma värde här samt i din riktiga `.env`
-# så att filer kan dekrypteras även efter omstart.
-PDF_ENCRYPTION_KEYS=w3dy6b8eBx0O0TADb8QWfXBxr6nMPNqY6kmv4hKoT1c=
+# Krypteringshemligheter för PDF-lagring. Ange en kommaseparerad lista med
+# hemliga fraser (till exempel `primar-hemlighet,tidigare-hemlighet`).
+# Applikationen härleder AES-nycklar via PBKDF2 och kan därmed dekryptera
+# filer så länge respektive fras finns kvar i listan även efter omstart.
+PDF_ENCRYPTION_KEYS=primar-hemlighet,tidigare-hemlighet
 
 # Database configuration
 # Supply credentials for the external PostgreSQL server that stores

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ This web application manages the issuance and storage of course certificates. It
    ```
 2. **Configure environment variables** – copy `.example.env` to `.env` and update the values to match your setup. Provide the credentials for your external PostgreSQL server by setting `POSTGRES_HOST`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, and optionally `POSTGRES_PORT`. The container derives the SQLAlchemy connection string from these values whenever `DATABASE_URL` is empty. If you prefer, you can instead set `DATABASE_URL` directly to a PostgreSQL connection string. For local development or automated tests you may temporarily enable `ENABLE_LOCAL_TEST_DB` to let the app create a SQLite database file defined by `LOCAL_TEST_DB_PATH`; the flag is disabled by default so production deployments still require PostgreSQL.
 
-   *Säker PDF-lagring*: sätt `PDF_ENCRYPTION_KEYS` till en kommaseparerad lista med [Fernet-nycklar](https://cryptography.io/en/latest/fernet/). Den första nyckeln används för att kryptera nyuppladdade filer och samtliga nycklar prövas i turordning vid dekryptering. Exempel:
+   *Säker PDF-lagring*: sätt `PDF_ENCRYPTION_KEYS` till en kommaseparerad lista med hemliga fraser. Applikationen härleder AES-nycklar via PBKDF2 på samma sätt som övrig känslig data i systemet. Den första frasen används för att kryptera nyuppladdade filer och samtliga fraser prövas i turordning vid dekryptering. Exempel:
 
    ```bash
-   PDF_ENCRYPTION_KEYS="<ny primär nyckel>,<tidigare nyckel>"
+   PDF_ENCRYPTION_KEYS="<ny primär fras>,<tidigare fras>"
    ```
 
-   Spara nyckelvärdet i din `.env`-fil (se `.example.env` för ett exempel) så att samma nyckel används vid varje omstart. Uppdatera variabeln och starta om applikationen för att rotera nycklar; behåll tidigare nycklar i listan tills alla äldre filer har krypterats om eller inte längre behövs.
+   Spara fraserna i din `.env`-fil (se `.example.env` för ett exempel) så att samma härledda nycklar används vid varje omstart. Uppdatera variabeln och starta om applikationen för att rotera fraser; behåll tidigare fraser i listan tills alla äldre filer har krypterats om eller inte längre behövs.
 3. **Run the application**
    ```bash
    python app.py

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,10 +26,10 @@ Tillsammans kan vi skapa en tryggare digital miljö.
 
 ## Kryptering av lagrade PDF:er
 
-Alla PDF-intyg krypteras med Fernet innan de sparas i databasen. Spara nyckelvärdet i din permanenta `.env`-fil så att samma nyckel används även efter en omstart. Du måste konfigurera miljövariabeln `PDF_ENCRYPTION_KEYS` med minst en giltig Fernet-nyckel (till exempel genererad via `python -m cryptography.fernet`). Vid nyckelrotation lägger du till den nya nyckeln först i listan och behåller tidigare nycklar efteråt:
+Alla PDF-intyg krypteras numera med AES-GCM där nycklarna härleds via PBKDF2 på samma sätt som övriga känsliga värden i applikationen. Spara hemligheterna i din permanenta `.env`-fil så att samma härledda nycklar används även efter en omstart. Du måste konfigurera miljövariabeln `PDF_ENCRYPTION_KEYS` med minst en hemlig fras (till exempel `primar-hemlighet`). Vid nyckelrotation lägger du till den nya frasen först i listan och behåller tidigare fraser efteråt:
 
 ```
-PDF_ENCRYPTION_KEYS="<ny primär nyckel>,<gammal nyckel>"
+PDF_ENCRYPTION_KEYS="<ny primär fras>,<gammal fras>"
 ```
 
-Starta om applikationen efter att variabeln har uppdaterats så att den nya nyckelordningen börjar användas. Systemet testar samtliga nycklar i ordning när ett dokument dekrypteras, vilket gör att äldre filer fortsätter att vara läsbara tills du tar bort deras nycklar från listan.
+Starta om applikationen efter att variabeln har uppdaterats så att den nya ordningen börjar användas. Systemet testar samtliga fraser i ordning när ett dokument dekrypteras, vilket gör att äldre filer fortsätter att vara läsbara tills du tar bort deras fraser från listan. Äldre dokument som tidigare krypterats med Fernet kan fortfarande dekrypteras så länge deras ursprungliga Fernet-nycklar finns kvar i variabeln.


### PR DESCRIPTION
## Summary
- derive PDF encryption keys with the existing PBKDF2 parameters and encrypt with AES-GCM
- keep Fernet decryption support for legacy blobs and extend the test suite to cover the new and old paths
- document the new key management approach in the README, SECURITY notes and example environment file

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dafe1ea9a0832d8173ca9ed4741a1e