### PR TITLE
Remove legacy Fernet PDF encryption fallback

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -20,11 +20,6 @@ secret_key=hemligt_session_varde
 # Salt used for hashing personal data such as email and personnummer
 HASH_SALT=extra_salt_for_hash
 
-# Krypteringsnycklar för PDF-lagring. Använd `python -m cryptography.fernet`
-# för att generera en nyckel och spara samma värde här samt i din riktiga `.env`
-# så att filer kan dekrypteras även efter omstart.
-PDF_ENCRYPTION_KEYS=w3dy6b8eBx0O0TADb8QWfXBxr6nMPNqY6kmv4hKoT1c=
-
 # Database configuration
 # Supply credentials for the external PostgreSQL server that stores
 # application data. POSTGRES_HOST is required when DATABASE_URL is empty.

--- a/README.md
+++ b/README.md
@@ -12,13 +12,7 @@ This web application manages the issuance and storage of course certificates. It
    ```
 2. **Configure environment variables** – copy `.example.env` to `.env` and update the values to match your setup. Provide the credentials for your external PostgreSQL server by setting `POSTGRES_HOST`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, and optionally `POSTGRES_PORT`. The container derives the SQLAlchemy connection string from these values whenever `DATABASE_URL` is empty. If you prefer, you can instead set `DATABASE_URL` directly to a PostgreSQL connection string. For local development or automated tests you may temporarily enable `ENABLE_LOCAL_TEST_DB` to let the app create a SQLite database file defined by `LOCAL_TEST_DB_PATH`; the flag is disabled by default so production deployments still require PostgreSQL.
 
-   *Säker PDF-lagring*: sätt `PDF_ENCRYPTION_KEYS` till en kommaseparerad lista med [Fernet-nycklar](https://cryptography.io/en/latest/fernet/). Den första nyckeln används för att kryptera nyuppladdade filer och samtliga nycklar prövas i turordning vid dekryptering. Exempel:
-
-   ```bash
-   PDF_ENCRYPTION_KEYS="<ny primär nyckel>,<tidigare nyckel>"
-   ```
-
-   Spara nyckelvärdet i din `.env`-fil (se `.example.env` för ett exempel) så att samma nyckel används vid varje omstart. Uppdatera variabeln och starta om applikationen för att rotera nycklar; behåll tidigare nycklar i listan tills alla äldre filer har krypterats om eller inte längre behövs.
+   *Säker PDF-lagring*: PDF-intyg krypteras med AES-GCM med en nyckel som härleds via samma PBKDF2-baserade hashning och `HASH_SALT` som används för lösenord och personnummer. Se därför till att `HASH_SALT` är satt i `.env` och håll värdet stabilt över tid så att uppladdade filer kan dekrypteras.
 3. **Run the application**
    ```bash
    python app.py

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,10 +26,4 @@ Tillsammans kan vi skapa en tryggare digital miljö.
 
 ## Kryptering av lagrade PDF:er
 
-Alla PDF-intyg krypteras med Fernet innan de sparas i databasen. Spara nyckelvärdet i din permanenta `.env`-fil så att samma nyckel används även efter en omstart. Du måste konfigurera miljövariabeln `PDF_ENCRYPTION_KEYS` med minst en giltig Fernet-nyckel (till exempel genererad via `python -m cryptography.fernet`). Vid nyckelrotation lägger du till den nya nyckeln först i listan och behåller tidigare nycklar efteråt:
-
-```
-PDF_ENCRYPTION_KEYS="<ny primär nyckel>,<gammal nyckel>"
-```
-
-Starta om applikationen efter att variabeln har uppdaterats så att den nya nyckelordningen börjar användas. Systemet testar samtliga nycklar i ordning när ett dokument dekrypteras, vilket gör att äldre filer fortsätter att vara läsbara tills du tar bort deras nycklar från listan.
+Alla PDF-intyg krypteras nu med AES-GCM innan de sparas i databasen. Krypteringsnyckeln härleds via samma PBKDF2-baserade hashfunktion och `HASH_SALT` som används för att skydda lösenord, personnummer och e-postadresser. Säkerställ därför att `HASH_SALT` är satt i din `.env`-fil och håll värdet oförändrat så länge du behöver komma åt befintliga intyg.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,11 +7,6 @@ import werkzeug
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
-os.environ.setdefault(
-    "PDF_ENCRYPTION_KEYS",
-    "dLw8JfQULF4tSHzxU_KgQPXujR5Ph9l9-Vw2hHkPnnI=",
-)
-
 import app  # noqa: E402
 import functions  # noqa: E402
 

--- a/tests/test_pdf_storage.py
+++ b/tests/test_pdf_storage.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from cryptography.fernet import Fernet
 from sqlalchemy import select
 
 import functions
@@ -76,6 +75,7 @@ def test_pdf_content_is_encrypted_at_rest(empty_db):
 
     _ = empty_db
 
+    functions.reset_pdf_encryption_cache()
     pnr_hash = _personnummer_hash("9001011234")
     original_content = b"%PDF-1.4 encrypted"
     pdf_id = functions.store_pdf_blob(
@@ -89,44 +89,15 @@ def test_pdf_content_is_encrypted_at_rest(empty_db):
         stored_blob = conn.execute(query).scalar_one()
 
     assert stored_blob != original_content
+    assert stored_blob[:4] == b"PDF2"
+    assert len(stored_blob) > 4 + 12
+
+    nonce = stored_blob[4:16]
+    ciphertext = stored_blob[16:]
+    aes_cipher = functions._get_pdf_aes_cipher()
+    manually_decrypted = aes_cipher.decrypt(nonce, ciphertext, None)
+    assert manually_decrypted == original_content
 
     filename, decrypted = functions.get_pdf_content(pnr_hash, pdf_id)
     assert filename == "encrypted.pdf"
     assert decrypted == original_content
-
-
-def test_pdf_key_rotation_allows_decryption_of_old_files(empty_db, monkeypatch):
-    """Äldre filer ska kunna dekrypteras när en nyckel roteras."""
-
-    _ = empty_db
-
-    current_keys = functions._load_pdf_encryption_keys()
-    original_key = current_keys[0]
-    functions.reset_pdf_encryption_cache()
-
-    pnr_hash = _personnummer_hash("9001011234")
-    legacy_content = b"%PDF-1.4 legacy"
-    pdf_id = functions.store_pdf_blob(
-        pnr_hash, "legacy.pdf", legacy_content, [COURSE_CATEGORIES[0][0]]
-    )
-
-    new_key = Fernet.generate_key().decode("ascii")
-    rotated_value = ",".join([new_key, original_key])
-    monkeypatch.setenv("PDF_ENCRYPTION_KEYS", rotated_value)
-    functions.reset_pdf_encryption_cache()
-
-    filename, decrypted = functions.get_pdf_content(pnr_hash, pdf_id)
-    assert filename == "legacy.pdf"
-    assert decrypted == legacy_content
-
-    fresh_pdf_id = functions.store_pdf_blob(
-        pnr_hash, "fresh.pdf", b"%PDF-1.4 fresh", [COURSE_CATEGORIES[0][0]]
-    )
-    with functions.get_engine().connect() as conn:
-        query = select(functions.user_pdfs_table.c.content).where(
-            functions.user_pdfs_table.c.id == fresh_pdf_id
-        )
-        stored_blob = conn.execute(query).scalar_one()
-
-    assert stored_blob != b"%PDF-1.4 fresh"
-


### PR DESCRIPTION
## Summary
- drop the Fernet-based PDF decryption path so PDFs are exclusively stored with the AES-GCM key derived from HASH_SALT
- remove environment variables, tests, and documentation references related to legacy Fernet keys

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfed0872f8832db8c3c815049f011c