### PR TITLE
Remove PDF encryption and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This web application manages the issuance and storage of course certificates. It
    ```
 2. **Configure environment variables** – copy `.example.env` to `.env` and update the values to match your setup. Provide the credentials for your external PostgreSQL server by setting `POSTGRES_HOST`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, and optionally `POSTGRES_PORT`. The container derives the SQLAlchemy connection string from these values whenever `DATABASE_URL` is empty. If you prefer, you can instead set `DATABASE_URL` directly to a PostgreSQL connection string. For local development or automated tests you may temporarily enable `ENABLE_LOCAL_TEST_DB` to let the app create a SQLite database file defined by `LOCAL_TEST_DB_PATH`; the flag is disabled by default so production deployments still require PostgreSQL.
 
-   *Säker PDF-lagring*: PDF-intyg krypteras med AES-GCM med en nyckel som härleds via samma PBKDF2-baserade hashning och `HASH_SALT` som används för lösenord och personnummer. Se därför till att `HASH_SALT` är satt i `.env` och håll värdet stabilt över tid så att uppladdade filer kan dekrypteras.
 3. **Run the application**
    ```bash
    python app.py

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,6 +24,3 @@ Inte delar informationen offentligt förrän vi har hunnit åtgärda problemet.
 
 Tillsammans kan vi skapa en tryggare digital miljö.
 
-## Kryptering av lagrade PDF:er
-
-Alla PDF-intyg krypteras nu med AES-GCM innan de sparas i databasen. Krypteringsnyckeln härleds via samma PBKDF2-baserade hashfunktion och `HASH_SALT` som används för att skydda lösenord, personnummer och e-postadresser. Säkerställ därför att `HASH_SALT` är satt i din `.env`-fil och håll värdet oförändrat så länge du behöver komma åt befintliga intyg.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,5 @@ itsdangerous==2.1.2
 click==8.1.7
 SQLAlchemy==2.0.43
 psycopg[binary]==3.2.10
-cryptography==46.0.1
-
 # Optional (for PDF validation if you later add more advanced checks)
 # PyPDF2==3.0.0


### PR DESCRIPTION
## Summary
- remove the encryption helpers so stored PDF blobs are saved and returned as-is
- update the PDF storage test to reflect plain storage and ensure retrieval works unchanged
- drop encryption-specific documentation and dependency declarations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e02bb71bc4832d9bf5e9344d85bc81