### PR TITLE
Fix SQLite test database path handling on Windows

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -217,8 +217,9 @@ def _build_engine() -> Engine:
                     raw_path = Path(APP_ROOT) / raw_path
                 raw_path.parent.mkdir(parents=True, exist_ok=True)
                 resolved = raw_path.resolve()
-                db_url = f"sqlite:///{resolved.as_posix()}"
-                logger.info("Using local SQLite test database at %s", resolved)
+                resolved_str = str(resolved)
+                db_url = f"sqlite:///{resolved_str}"
+                logger.info("Using local SQLite test database at %s", resolved_str)
         else:
             host = os.getenv("POSTGRES_HOST")
             if not host:


### PR DESCRIPTION
## Summary
- ensure the local SQLite test database path uses the platform specific path representation
- update logging to reflect the normalized path string

## Testing
- pytest tests/test_functions_additional.py::test_enable_local_test_db_creates_sqlite *(fails: unrelated SyntaxError in app.py during import)*

------
https://chatgpt.com/codex/tasks/task_e_68e52ac29a78832d9e33b9edbc5a961e