### PR TITLE
Byt plats på hero-räls och åtgärdspanel på startsidan

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -1367,6 +1367,9 @@ small.hint {
     position: relative;
     display: grid;
     grid-template-columns: minmax(0, 1.2fr) minmax(260px, 0.8fr);
+    grid-template-areas:
+        "text actions"
+        "rail actions";
     gap: clamp(1.6rem, 4vw, 2.8rem);
     align-items: start;
     padding: clamp(2.25rem, 5vw, 3.4rem);
@@ -1392,6 +1395,7 @@ small.hint {
 }
 
 .hero-text {
+    grid-area: text;
     display: grid;
     gap: 1.15rem;
     align-content: start;
@@ -1450,10 +1454,15 @@ small.hint {
 }
 
 .hero-actions {
+    grid-area: actions;
     display: grid;
     gap: 0.65rem;
-    align-items: start;
-    margin-top: 0.25rem;
+    align-content: start;
+    padding: 1.2rem 1.25rem 1.35rem;
+    background: rgba(255, 255, 255, 0.72);
+    border: 1px solid rgba(156, 30, 10, 0.18);
+    border-radius: 0.7rem;
+    box-shadow: 0 18px 35px rgba(55, 55, 55, 0.08);
 }
 
 .hero-btn {
@@ -1514,7 +1523,7 @@ small.hint {
 
 .hero-tracks {
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
     gap: 0.55rem;
     margin-top: 0.25rem;
 }
@@ -1547,6 +1556,7 @@ small.hint {
 }
 
 .hero-rail {
+    grid-area: rail;
     display: grid;
     gap: 0.95rem;
     align-content: start;
@@ -2558,6 +2568,9 @@ small.hint {
 
     main.main-home .home-hero {
         grid-template-columns: minmax(0, 1.25fr) minmax(320px, 0.75fr);
+        grid-template-areas:
+            "text actions"
+            "rail actions";
         gap: clamp(2rem, 3vw, 3rem);
         padding: clamp(2.4rem, 4vw, 3.4rem);
     }
@@ -2883,6 +2896,10 @@ small.hint {
 
     .home-hero {
         grid-template-columns: 1fr;
+        grid-template-areas:
+            "text"
+            "rail"
+            "actions";
     }
 
     .trust-band {
@@ -3013,6 +3030,10 @@ small.hint {
 
     .hero-tracks {
         gap: 0.45rem;
+    }
+
+    .hero-actions {
+        padding: 1rem;
     }
 
     .benefit-list {

--- a/templates/index.html
+++ b/templates/index.html
@@ -37,26 +37,6 @@
                 <li data-motion-child>Se vad som är uppladdat, delat och klart</li>
                 <li data-motion-child>Hantera personuppgifter med GDPR-anpassad struktur</li>
             </ul>
-
-            <div class="hero-actions" aria-label="Primära handlingar" data-motion-group="hero-actions">
-                <u class="home-more-details" style="color:#9C1E0A; font-weight: 700; text-decoration: underline; text-decoration-thickness: 0.08em; text-underline-offset: 0.2em;">Ansök här</u>
-                <div class="hero-tracks" aria-label="Välj användarspår" data-motion-group="hero-tracks">
-                    <a class="btn hero-btn hero-btn-primary" href="{{ url_for('apply_standardkonto') }}" data-motion-child>Privatperson</a>
-                    <a class="btn hero-btn hero-btn-primary" href="{{ url_for('apply_foretagskonto') }}" data-motion-child>Företag</a>
-                </div>
-                <p class="hero-action-note" data-motion-child>
-                    <a class="hero-inline-link" href="/pris">Se priser</a>
-                    <span aria-hidden="true">•</span>
-                    {% if DEMO_SITE_URL %}
-                        <a class="hero-inline-link" href="{{ DEMO_SITE_URL }}" rel="noopener">Prova demo</a>
-                    {% elif IS_DEMO %}
-                        <a class="hero-inline-link" href="/login">Prova demo</a>
-                    {% else %}
-                        <a class="hero-inline-link" href="mailto:support@utbildningsintyg.se?subject=Boka%20demo">Boka demo</a>
-                    {% endif %}
-                </p>
-                
-            </div>
         </div>
         <aside class="hero-rail" aria-label="Kontoval" data-motion-group="hero-rail">
             <p class="hero-rail-label" data-motion-child>Välj konto</p>
@@ -73,6 +53,24 @@
             </ol>
             <p class="hero-rail-foot" data-motion-child>Privatkonto är kostnadsfritt för privatpersoner.</p>
         </aside>
+        <div class="hero-actions" aria-label="Primära handlingar" data-motion-group="hero-actions">
+            <u class="home-more-details" style="color:#9C1E0A; font-weight: 700; text-decoration: underline; text-decoration-thickness: 0.08em; text-underline-offset: 0.2em;">Ansök här</u>
+            <div class="hero-tracks" aria-label="Välj användarspår" data-motion-group="hero-tracks">
+                <a class="btn hero-btn hero-btn-primary" href="{{ url_for('apply_standardkonto') }}" data-motion-child>Privatperson</a>
+                <a class="btn hero-btn hero-btn-primary" href="{{ url_for('apply_foretagskonto') }}" data-motion-child>Företag</a>
+            </div>
+            <p class="hero-action-note" data-motion-child>
+                <a class="hero-inline-link" href="/pris">Se priser</a>
+                <span aria-hidden="true">•</span>
+                {% if DEMO_SITE_URL %}
+                    <a class="hero-inline-link" href="{{ DEMO_SITE_URL }}" rel="noopener">Prova demo</a>
+                {% elif IS_DEMO %}
+                    <a class="hero-inline-link" href="/login">Prova demo</a>
+                {% else %}
+                    <a class="hero-inline-link" href="mailto:support@utbildningsintyg.se?subject=Boka%20demo">Boka demo</a>
+                {% endif %}
+            </p>
+        </div>
     </section>
 
     <section class="trust-band" aria-labelledby="trust-title" data-motion="section">

--- a/tests/test_ui_rendering.py
+++ b/tests/test_ui_rendering.py
@@ -139,6 +139,18 @@ def test_home_page_exposes_motion_markers(empty_db):
     assert 'data-motion-group="benefits"' in body
 
 
+
+def test_home_page_hero_places_account_rail_before_action_panel(empty_db):
+    with _client() as client:
+        response = client.get("/")
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+
+    rail_index = body.index('class="hero-rail"')
+    actions_index = body.index('class="hero-actions"')
+
+    assert rail_index < actions_index
+
 def test_apply_and_pricing_pages_expose_motion_markers(empty_db):
     with _client() as client:
         apply_response = client.get("/ansok")


### PR DESCRIPTION
### Motivation
- Förbättra layouten på startsidan så att konto-valsrälsen (`.hero-rail`) visas före åtgärdspanelen/knapparna för att ge tydligare informationshierarki. 
- Separera actions till en egen panel så den kan stylas som ett kort och fungera bättre i responsiva grid-layouter.

### Description
- Flyttade markup för `.hero-actions` i `templates/index.html` så att `.hero-rail` renderas före action-panelen. 
- Uppdaterade `static/css/base.css` för att använda `grid-template-areas` och tilldelade `grid-area` för `.hero-text`, `.hero-rail` och `.hero-actions`, samt gjorde action-panelen till ett synligt kort och stackade knapparna vertikalt. 
- Justerade responsiva regler så beteendet bevaras på stora och små skärmar. 
- Lade till UI-regressionstestet `test_home_page_hero_places_account_rail_before_action_panel` i `tests/test_ui_rendering.py` som verifierar att rälsen renderas före åtgärdspanelen.

### Testing
- Körde `pytest -n auto tests/test_ui_rendering.py` och alla testexempel körda i den filen passerade (`9 passed`). 
- Det nya testet `test_home_page_hero_places_account_rail_before_action_panel` kördes som del av testsviten och lyckades.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbb89ecef8832d810282dd0510247b)