### PR TITLE
Ta bort kortliknande styling från hero-knappar på startsidan

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -1458,11 +1458,6 @@ small.hint {
     display: grid;
     gap: 0.65rem;
     align-content: start;
-    padding: 1.2rem 1.25rem 1.35rem;
-    background: rgba(255, 255, 255, 0.72);
-    border: 1px solid rgba(156, 30, 10, 0.18);
-    border-radius: 0.7rem;
-    box-shadow: 0 18px 35px rgba(55, 55, 55, 0.08);
 }
 
 .hero-btn {
@@ -3032,9 +3027,6 @@ small.hint {
         gap: 0.45rem;
     }
 
-    .hero-actions {
-        padding: 1rem;
-    }
 
     .benefit-list {
         grid-template-columns: 1fr;


### PR DESCRIPTION
### Motivation
- Förenkla layouten i startsidans hero genom att ta bort det separata kortet runt åtgärdsknapparna så knapparna ligger direkt i hero-sektionen.

### Description
- Uppdaterat `static/css/base.css` för att ta bort padding, bakgrund, ram, `border-radius` och `box-shadow` från `.hero-actions` så knapparna inte längre presenteras som ett eget kort. 
- Tog även bort den mobil-specifika `padding`-override för `.hero-actions` i responsiva regler för att behålla en konsekvent, förenklad presentation.
- Ingen ändring i mallfilerna (`templates/index.html`) eller knappstrukturen, endast stiljusteringar i CSS.

### Testing
- Körda tester: `pytest -n auto tests/test_ui_rendering.py tests/test_pricing_page.py` och alla tester passerade (`12 passed`).
- Ingen skärmdump bifogad eftersom verktyg för att ta visuella skärmdumpar inte var tillgängligt i denna miljö.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbbbc7a7f4832d8c1b1c2fab2951ee)