### PR TITLE
Placera 'Privatperson' och 'Företag' knappar sida‑vid‑sida i hero

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -1518,7 +1518,8 @@ small.hint {
 
 .hero-tracks {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    flex-wrap: wrap;
     gap: 0.55rem;
     margin-top: 0.25rem;
 }


### PR DESCRIPTION
### Motivation
- Förbättra startsidans hero-layout genom att visa valen "Privatperson" och "Företag" bredvid varandra på bredare vyer samtidigt som mobilbrytning behålls.

### Description
- Uppdaterade `static/css/base.css` genom att ändra `.hero-tracks` från `flex-direction: column;` till `flex-direction: row;` och lade till `flex-wrap: wrap;` så att knapparna visas horisontellt men fortfarande kan brytas till nästa rad vid smalare skärmar.

### Testing
- Körde `pytest -n auto tests/test_ui_rendering.py` och testsviten körde klart och passerade i denna miljö; ingen skärmdump kunde bifogas eftersom screenshot-funktionalitet inte var tillgänglig.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbbd1c23b0832da80aa960839f1cff)